### PR TITLE
Use Mesh API for 6LoWPAN networking

### DIFF
--- a/module.json
+++ b/module.json
@@ -13,7 +13,8 @@
     }
   ],
   "dependencies": {
-    "mbed-client-c": "~0.1.6"
+    "mbed-client-c": "~0.1.6",
+    "atmel-rf-driver": "~0.0.13"
   },
   "targetDependencies": {
     "arm": {

--- a/test/helloworld-lwm2mclient/m2mlwclient.cpp
+++ b/test/helloworld-lwm2mclient/m2mlwclient.cpp
@@ -6,7 +6,7 @@
 #include "lwm2m-client/m2mobjectinstance.h"
 #include "lwm2m-client/m2mresource.h"
 
-
+#define SIXLOWPAN_INTERFACE
 // Enter your mbed Device Server's IPv4 address and Port number in
 // mentioned format like 192.168.0.1:5693
 const String &BOOTSTRAP_SERVER_ADDRESS = "coap://10.45.3.10:5693";
@@ -19,10 +19,10 @@ const String &MBED_SERVER_DTLS_ADDRESS = "coap://FD00:FF1:CE0B:A5E1:1068:AF13:9B
 //const String &MBED_SERVER_ADDRESS = "coap://10.45.3.10:5683";
 //const String &MBED_SERVER_DTLS_ADDRESS = "coap://10.45.3.10:5684";
 const String &MBED_SERVER_ADDRESS = "coap://10.45.0.152:5683";
-const uint16_t SERVER_PORT = 5683;
 const String &MBED_SERVER_DTLS_ADDRESS = "coap://10.45.0.152:5684";
-const uint16_t SECURE_PORT = 5684;
 #endif
+const uint16_t SERVER_PORT = 5683;
+const uint16_t SECURE_PORT = 5684;
 const String &MANUFACTURER = "ARM";
 const String &TYPE = "type";
 const String &MODEL_NUMBER = "2015";


### PR DESCRIPTION
Application updated to use mbed-mesh-api. 
6LoWPAN flags enabled and module.json updated to use rf-driver.

@yogpan01 , please check and modify as needed.
