### PR TITLE
Fix for IOTCLT-239

### DIFF
--- a/source/m2mresource.cpp
+++ b/source/m2mresource.cpp
@@ -152,7 +152,11 @@ bool M2MResource::handle_observation_attribute(char *&query)
             success = (*it)->handle_observation_attribute(query);
         }
     } else {
-        success = M2MBase::handle_observation_attribute(query);
+        tr_debug("M2MResource::handle_observation_attribute() - else");
+        // Apply write attributes only if resource is numerical
+        if (_resource_type == M2MResourceInstance::INTEGER ||
+            _resource_type == M2MResourceInstance::FLOAT)
+            success = M2MBase::handle_observation_attribute(query);
     }
     return success;
 }

--- a/source/m2mresourceinstance.cpp
+++ b/source/m2mresourceinstance.cpp
@@ -117,7 +117,14 @@ M2MResourceInstance::ResourceType M2MResourceInstance::resource_instance_type() 
 bool M2MResourceInstance::handle_observation_attribute(char *&query)
 {
     tr_debug("M2MResourceInstance::handle_observation_attribute()");
-    return M2MBase::handle_observation_attribute(query);
+    if (resource_instance_type() == M2MResourceInstance::INTEGER ||
+        resource_instance_type() == M2MResourceInstance::FLOAT ){
+        return M2MBase::handle_observation_attribute(query);
+    }
+    else {
+        tr_debug("M2MResourceInstance::handle_observation_attribute() - write attribute is not numerical");
+        return false;
+    }
 }
 
 void M2MResourceInstance::set_execute_function(execute_callback callback)


### PR DESCRIPTION
- Greater than, Less than and Step attributes can be defined only if resource type is numerical
