### PR TITLE
Add multi instance to resource creation in test application

### DIFF
--- a/test/lwm2mtestapplication/lwm2mtest.cpp
+++ b/test/lwm2mtestapplication/lwm2mtest.cpp
@@ -399,7 +399,7 @@ bool M2MLWClient::create_dynamic_resource_string(const char *name,
         if(inst) {
             M2MResource *res = inst->create_dynamic_resource(name,"resource",
                                                              M2MResourceInstance::STRING,
-                                                             observable);
+                                                             observable, multiple_instance);
             if(res) {
                 success = true;
                 res->set_operation(int_to_operation(resource_operation));
@@ -425,7 +425,7 @@ bool M2MLWClient::create_dynamic_resource_int(const char *name,
         if(inst) {
             M2MResource *res = inst->create_dynamic_resource(name,"resource",
                                                              M2MResourceInstance::INTEGER,
-                                                             observable);
+                                                             observable, multiple_instance);
             if(res) {
                 success = true;
                 res->set_operation(int_to_operation(resource_operation));


### PR DESCRIPTION
Multiple instance parameter is now passed from the command to create dynamic resource.