### PR TITLE
Fix notification sending when pmin == pmax

### DIFF
--- a/source/m2mreporthandler.cpp
+++ b/source/m2mreporthandler.cpp
@@ -327,12 +327,16 @@ void M2MReportHandler::handle_timers()
 {
     uint64_t time_interval = 0;    
     if(_pmin > 0) {
-        _pmin_exceeded = false;
-        time_interval = (uint64_t)(_pmin * 1000);
-        tr_debug("M2MReportHandler::handle_timers() - Start PMIN interval: %d", (int)time_interval);
-        _pmin_timer->start_timer(time_interval,
-                                 M2MTimerObserver::PMinTimer,
-                                 true);
+        if (_pmin == _pmax) {
+            _pmin_exceeded = true;
+        } else {
+            _pmin_exceeded = false;
+            time_interval = (uint64_t)(_pmin * 1000);
+            tr_debug("M2MReportHandler::handle_timers() - Start PMIN interval: %d", (int)time_interval);
+            _pmin_timer->start_timer(time_interval,
+                                     M2MTimerObserver::PMinTimer,
+                                     true);
+        }
     }
     if (_pmax > 0) {
         time_interval = (uint64_t)(_pmax * 1000);
@@ -347,7 +351,7 @@ bool M2MReportHandler::check_attribute_validity()
 {
     bool success = true;
     if ((_attribute_state & M2MReportHandler::Pmax) == M2MReportHandler::Pmax &&
-            ((_pmax >= -1.0f) && (_pmin >= _pmax))) {
+            ((_pmax >= -1.0f) && (_pmin > _pmax))) {
         success = false;
     }
     float low = _lt + 2 * _st;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ ENDFOREACH()
 
 endif()
 
-if(TARGET_LIKE_LINUX)
+if(TARGET_LIKE_LINUX AND NOT TARGET_LIKE_X86_LINUX_NATIVE_COVERAGE)
 add_executable(mbed-client-test-mbedclient_linux 
         "mbedclient_linux/main.cpp"
 )

--- a/test/mbedclient/utest/m2mreporthandler/test_m2mreporthandler.cpp
+++ b/test/mbedclient/utest/m2mreporthandler/test_m2mreporthandler.cpp
@@ -122,6 +122,9 @@ void Test_M2MReportHandler::test_parse_notification_attribute()
     char* val10_real = {"pmax=30&lt=10&gt=19&pmin=1&st=4"};
     CHECK(true == _handler->parse_notification_attribute(val10_real, M2MBase::Resource ));
 
+    char* val11_real = {"pmax=30&pmin=30"};
+    CHECK(true == _handler->parse_notification_attribute(val11_real, M2MBase::Resource ));
+
     char* val4_real = {"cancel"};
     CHECK(true == _handler->parse_notification_attribute(val4_real, M2MBase::Resource ));
     DOUBLES_EQUAL(0,_handler->_lt,0);


### PR DESCRIPTION
Fixes error:
 * IOTCLT-302 - Sometimes notification is not sent after write attribute operation with pmin = pmax