### PR TITLE
Fix for API rename.

### DIFF
--- a/mbed-client/m2mconnectionhandler.h
+++ b/mbed-client/m2mconnectionhandler.h
@@ -108,7 +108,7 @@ public:
      * @param len Length of a buffer.
      * @return Number of bytes sent or -1 if failed.
      */
-    int sendToSocket(const unsigned char *buf, size_t len);
+    int send_to_socket(const unsigned char *buf, size_t len);
 
     /**
      * @brief receiveFromSocket Receives directly from a socket. This
@@ -117,7 +117,7 @@ public:
      * @param len Length of a buffer.
      * @return Number of bytes read or -1 if failed.
      */
-    int receiveFromSocket(unsigned char *buf, size_t len);
+    int receive_from_socket(unsigned char *buf, size_t len);
 
 
     /**

--- a/test/mbedclient/utest/stub/m2mconnectionhandler_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mconnectionhandler_stub.cpp
@@ -73,10 +73,10 @@ void M2MConnectionHandler::stop_listening()
 {
 }
 
-int M2MConnectionHandler::sendToSocket(const unsigned char *, size_t ){
+int M2MConnectionHandler::send_to_socket(const unsigned char *, size_t ){
     return m2mconnectionhandler_stub::int_value;
 }
 
-int M2MConnectionHandler::receiveFromSocket(unsigned char *buf, size_t len){
+int M2MConnectionHandler::receive_from_socket(unsigned char *, size_t){
     return m2mconnectionhandler_stub::int_value;
 }


### PR DESCRIPTION
 - sendToSocket renamed to send_to_socket()
 - receiveFromSocket renamed to receive_from_socket()