### PR TITLE
Removing mDS and mbed DS references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ARM mbed Client
 =======================
 
-This repository contains ARM mbed Client: a library that connects devices to mbed Device Connector Service, mbed Device Server (mDS) and to mbed-enabled cloud services from our partners.
+This repository contains ARM mbed Client: a library that connects devices to mbed Device Connector Service, mbed Device Server and to mbed-enabled cloud services from our partners.
 
 The documentation is collected under the docs directory and the **mbed Client Guide** is also hosted [here](https://docs.mbed.com/docs/mbed-client-guide/en/latest/).
 


### PR DESCRIPTION
We should call it mbed Device Server from now on