### PR TITLE
int64->int32

### DIFF
--- a/mbed-client/m2mdevice.h
+++ b/mbed-client/m2mdevice.h
@@ -112,7 +112,7 @@ public:
      * @param value, Value to be set on the resource, in Integer format.
      * @return M2MResource if created successfully, else NULL.
      */
-    M2MResource* create_resource(DeviceResource resource, int64_t value);
+    M2MResource* create_resource(DeviceResource resource, int32_t value);
 
     /**
      * @brief Creates a new resource instance for given resource enum.
@@ -122,7 +122,8 @@ public:
      * @param value, Value to be set on the resource, in Integer format.
      * @return M2MResourceInstance if created successfully, else NULL.
      */
-    M2MResourceInstance* create_resource_instance(DeviceResource resource, int64_t value,
+
+    M2MResourceInstance* create_resource_instance(DeviceResource resource, int32_t value,
                                                   uint16_t instance_id);
 
     /**
@@ -176,7 +177,7 @@ public:
      * @return True if successfully set, else false.
      */
     bool set_resource_value(DeviceResource resource,
-                            int64_t value,
+                            int32_t value,
                             uint16_t instance_id = 0);
 
     /**
@@ -200,7 +201,7 @@ public:
      * @param instance_id, Instance Id of the resource, default is 0
      * @return Value associated with that resource. If the resource is not valid -1 is returned.
      */
-    int64_t resource_value_int(DeviceResource resource,
+    int32_t resource_value_int(DeviceResource resource,
                                uint16_t instance_id = 0) const;
 
     /**
@@ -232,7 +233,7 @@ private:
 
     String resource_name(DeviceResource resource) const;
 
-    bool check_value_range(DeviceResource resource, const int64_t value) const;
+    bool check_value_range(DeviceResource resource, const int32_t value) const;
 
 private :
 

--- a/mbed-client/m2mfirmware.h
+++ b/mbed-client/m2mfirmware.h
@@ -116,7 +116,7 @@ public:
      * @param value, Value to be set on the resource, in Integer format.
      * @return M2MResource if created successfully, else NULL.
      */
-    M2MResource* create_resource(FirmwareResource resource, int64_t value);
+    M2MResource* create_resource(FirmwareResource resource, int32_t value);
 
     /**
      * @brief Deletes the resource with the given resource enum.
@@ -144,7 +144,7 @@ public:
      * @return True if successfully set, else false.
      */
     bool set_resource_value(FirmwareResource resource,
-                            int64_t value);
+                            int32_t value);
 
     /**
      * @brief Sets the value of the given resource enum.
@@ -172,7 +172,7 @@ public:
      * 'State','UpdateSupportedObjects','UpdateResult'.     
      * @return Value associated with that resource. If the resource is not valid -1 is returned.
      */
-    int64_t resource_value_int(FirmwareResource resource) const;
+    int32_t resource_value_int(FirmwareResource resource) const;
 
     /**
      * @brief Populates the data buffer and returns the size of the buffer.
@@ -215,7 +215,7 @@ private:
 
     void create_mandatory_resources();
 
-    bool check_value_range(FirmwareResource resource, const int64_t value) const;
+    bool check_value_range(FirmwareResource resource, const int32_t value) const;
 
 private :
 

--- a/source/m2mdevice.cpp
+++ b/source/m2mdevice.cpp
@@ -141,8 +141,10 @@ M2MResource* M2MDevice::create_resource(DeviceResource resource, const String &v
     return res;
 }
 
-M2MResource* M2MDevice::create_resource(DeviceResource resource, int64_t value)
+M2MResource* M2MDevice::create_resource(DeviceResource resource, int32_t value)
 {
+    tr_debug("M2MDevice::create_resource with value %ld", (long int) value);
+
     M2MResource* res = NULL;
     String device_id = "";
     M2MBase::Operation operation = M2MBase::GET_ALLOWED;
@@ -182,10 +184,10 @@ M2MResource* M2MDevice::create_resource(DeviceResource resource, int64_t value)
             if(res) {
                 char *buffer = (char*)memory_alloc(20);
                 if(buffer) {
-                    int size = snprintf(buffer, 20,"%lld", (long long int)value);
+                    uint32_t size = snprintf(buffer, 20,"%ld", (long int)value);
                     res->set_operation(operation);
                     res->set_value((const uint8_t*)buffer,
-                                   (uint32_t)size);
+                                   size);
                     memory_free(buffer);
                 }
             }
@@ -194,16 +196,18 @@ M2MResource* M2MDevice::create_resource(DeviceResource resource, int64_t value)
     return res;
 }
 
-M2MResourceInstance* M2MDevice::create_resource_instance(DeviceResource resource, int64_t value,
+M2MResourceInstance* M2MDevice::create_resource_instance(DeviceResource resource, int32_t value,
                                                  uint16_t instance_id)
 {
+    tr_debug("M2MDevice::create_resource with value %ld at instance %d", (long int)value, instance_id);
+
     M2MResourceInstance* res = NULL;
     String device_id = "";    
     // For these resources multiple instance can exist
     if(AvailablePowerSources == resource) {
         if(check_value_range(resource, value)) {
             device_id = DEVICE_AVAILABLE_POWER_SOURCES;
-        }
+    }
     } else if(PowerSourceVoltage == resource) {
         device_id = DEVICE_POWER_SOURCE_VOLTAGE;
     } else if(PowerSourceCurrent == resource) {
@@ -223,11 +227,11 @@ M2MResourceInstance* M2MDevice::create_resource_instance(DeviceResource resource
             if(res) {
                 char *buffer = (char*)memory_alloc(20);
                 if(buffer) {
-                    int size = snprintf(buffer, 20,"%lld", (long long int)value);
+                    uint32_t size = snprintf(buffer, 20,"%ld", (long int)value);
                     // Only read operation is allowed for above resources
                     res->set_operation(M2MBase::GET_ALLOWED);
                     res->set_value((const uint8_t*)buffer,
-                                   (uint32_t)size);
+                                   size);
                     memory_free(buffer);
                 }
             }
@@ -237,6 +241,8 @@ M2MResourceInstance* M2MDevice::create_resource_instance(DeviceResource resource
 }
 M2MResource* M2MDevice::create_resource(DeviceResource resource)
 {
+    tr_debug("M2MDevice::create_resource %d", resource);
+
     M2MResource* res = NULL;
     if(!is_resource_present(resource)) {
         String device_Id;
@@ -289,6 +295,8 @@ bool M2MDevice::set_resource_value(DeviceResource resource,
                                    const String &value,
                                    uint16_t instance_id)
 {
+    tr_debug("M2MDevice::set_resource at instance_id %d", instance_id);
+
     bool success = false;
     M2MResourceInstance* res = get_resource_instance(resource,instance_id);
     if(res && value.size() <= MAX_ALLOWED_STRING_LENGTH) {
@@ -313,9 +321,11 @@ bool M2MDevice::set_resource_value(DeviceResource resource,
 }
 
 bool M2MDevice::set_resource_value(DeviceResource resource,
-                                       int64_t value,
+                                       int32_t value,
                                        uint16_t instance_id)
 {
+    tr_debug("M2MDevice::set_resource with value %ld at instance_id %d", (long int)value, instance_id);
+
     bool success = false;
     M2MResourceInstance* res = get_resource_instance(resource,instance_id);
     if(res) {
@@ -333,9 +343,9 @@ bool M2MDevice::set_resource_value(DeviceResource resource,
             if (check_value_range(resource, value)) {
                 char *buffer = (char*)memory_alloc(20);
                 if(buffer) {
-                    int size = snprintf(buffer, 20,"%lld",(long long int)value);
+                    uint32_t size = snprintf(buffer, 20,"%ld", (long int)value);
                     success = res->set_value((const uint8_t*)buffer,
-                                             (uint32_t)size);
+                                             size);
                     memory_free(buffer);
                 }
             }
@@ -347,6 +357,8 @@ bool M2MDevice::set_resource_value(DeviceResource resource,
 String M2MDevice::resource_value_string(DeviceResource resource,
                                         uint16_t instance_id) const
 {
+    tr_debug("M2MDevice::resource_value_string instance_id %d", instance_id);
+
     String value = "";
     M2MResourceInstance* res = get_resource_instance(resource,instance_id);
     if(res) {
@@ -383,10 +395,12 @@ String M2MDevice::resource_value_string(DeviceResource resource,
     return value;
 }
 
-int64_t M2MDevice::resource_value_int(DeviceResource resource,
+int32_t M2MDevice::resource_value_int(DeviceResource resource,
                                       uint16_t instance_id) const
 {
-    int64_t value = -1;
+    tr_debug("M2MDevice::resource_value_int instance_id %d", instance_id);
+
+    int32_t value = -1;
     M2MResourceInstance* res = get_resource_instance(resource,instance_id);
     if(res) {
         if(M2MDevice::BatteryLevel == resource          ||
@@ -531,7 +545,7 @@ String M2MDevice::resource_name(DeviceResource resource) const
     return res_name;
 }
 
-bool M2MDevice::check_value_range(DeviceResource resource, int64_t value) const
+bool M2MDevice::check_value_range(DeviceResource resource, int32_t value) const
 {
     bool success = false;
     switch (resource) {

--- a/source/m2mfirmware.cpp
+++ b/source/m2mfirmware.cpp
@@ -133,7 +133,7 @@ M2MResource* M2MFirmware::create_resource(FirmwareResource resource, const Strin
     return res;
 }
 
-M2MResource* M2MFirmware::create_resource(FirmwareResource resource, int64_t value)
+M2MResource* M2MFirmware::create_resource(FirmwareResource resource, int32_t value)
 {
     M2MResource* res = NULL;
     String firmware_id = "";
@@ -160,11 +160,11 @@ M2MResource* M2MFirmware::create_resource(FirmwareResource resource, int64_t val
             if(res) {
                 char *buffer = (char*)memory_alloc(20);
                 if(buffer) {
-                    int size = snprintf(buffer, 20,"%lld",(long long int)value);
+                    uint32_t size = snprintf(buffer, 20,"%ld",(long int)value);
 
                     res->set_operation(operation);
                     res->set_value((const uint8_t*)buffer,
-                                   (uint32_t)size);
+                                   size);
                     memory_free(buffer);
                 }
             }
@@ -196,7 +196,7 @@ bool M2MFirmware::set_resource_value(FirmwareResource resource,
 }
 
 bool M2MFirmware::set_resource_value(FirmwareResource resource,
-                                       int64_t value)
+                                       int32_t value)
 {
     bool success = false;
     M2MResource* res = get_resource(resource);
@@ -209,9 +209,9 @@ bool M2MFirmware::set_resource_value(FirmwareResource resource,
             if (check_value_range(resource, value)) {
                 char *buffer = (char*)memory_alloc(20);
                 if(buffer) {
-                    int size = snprintf(buffer, 20,"%lld",(long long int)value);
+                    uint32_t size = snprintf(buffer, 20,"%ld",(long int)value);
                     success = res->set_value((const uint8_t*)buffer,
-                                             (uint32_t)size);
+                                             size);
                     memory_free(buffer);
                 }
             }
@@ -356,9 +356,9 @@ bool M2MFirmware::delete_resource(FirmwareResource resource)
     return success;
 }
 
-int64_t M2MFirmware::resource_value_int(FirmwareResource resource) const
+int32_t M2MFirmware::resource_value_int(FirmwareResource resource) const
 {
-    int64_t value = -1;
+    int32_t value = -1;
     M2MResource* res = get_resource(resource);
     if(res) {
         if(M2MFirmware::State == resource          ||
@@ -408,7 +408,7 @@ String M2MFirmware::resource_value_string(FirmwareResource resource) const
     return value;
 }
 
-bool M2MFirmware::check_value_range(FirmwareResource resource, int64_t value) const
+bool M2MFirmware::check_value_range(FirmwareResource resource, int32_t value) const
 {
     bool success = false;
     switch (resource) {

--- a/test/lwm2mtestapplication/lwm2mtest.cpp
+++ b/test/lwm2mtestapplication/lwm2mtest.cpp
@@ -190,7 +190,7 @@ bool M2MLWClient::create_device_object()
 }
 
 bool M2MLWClient::create_device_object(M2MDevice::DeviceResource resource,
-                          int64_t value)
+                          int32_t value)
 {
     bool success = false;
     if(!_device) {
@@ -207,7 +207,7 @@ bool M2MLWClient::create_device_object(M2MDevice::DeviceResource resource,
 }
 
 bool M2MLWClient::create_device_object(M2MDevice::DeviceResource resource,
-                                       int64_t value,
+                                       int32_t value,
                                        uint16_t instance_id)
 {
     bool success = false;
@@ -258,7 +258,7 @@ bool M2MLWClient::create_firmware_object()
 }
 
 bool M2MLWClient::create_firmware_object(M2MFirmware::FirmwareResource resource,
-                          int64_t value)
+                          int32_t value)
 {
     bool success = false;
     if(!_firmware) {
@@ -367,7 +367,7 @@ bool M2MLWClient::create_static_resource_string(const char *name,
 }
 
 bool M2MLWClient::create_static_resource_int(const char *name,
-                                             int64_t value,
+                                             int32_t value,
                                              bool multiple_instance,
                                              uint16_t object_instance)
 {

--- a/test/lwm2mtestapplication/lwm2mtest.h
+++ b/test/lwm2mtestapplication/lwm2mtest.h
@@ -49,11 +49,11 @@ public:
                               const char *value);
 
     bool create_device_object(M2MDevice::DeviceResource resource,
-                              int64_t value,
+                              int32_t value,
                               uint16_t instance_id);
 
     bool create_device_object(M2MDevice::DeviceResource resource,
-                              int64_t value);
+                              int32_t value);
 
     bool create_firmware_object();
 
@@ -61,7 +61,7 @@ public:
                               const char *value);
 
     bool create_firmware_object(M2MFirmware::FirmwareResource resource,
-                              int64_t value);
+                              int32_t value);
 
     bool create_firmware_object(M2MFirmware::FirmwareResource resource,
                                 const uint8_t *value,
@@ -86,7 +86,7 @@ public:
                                        uint16_t object_instance = 0);
 
     bool create_static_resource_int(const char *name,
-                                    int64_t value,
+                                    int32_t value,
                                     bool multiple_instance,
                                     uint16_t object_instance = 0);
 

--- a/test/mbedclient/utest/stub/m2mdevice_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mdevice_stub.cpp
@@ -74,7 +74,7 @@ bool M2MDevice::set_resource_value(DeviceResource,
 }
 
 bool M2MDevice::set_resource_value(DeviceResource,
-                                       int64_t,
+                                       int32_t,
                                        uint16_t)
 {
     return m2mdevice_stub::bool_value;
@@ -86,7 +86,7 @@ String M2MDevice::resource_value_string(DeviceResource,
     return m2mdevice_stub::string_value;
 }
 
-int64_t M2MDevice::resource_value_int(DeviceResource,
+int32_t M2MDevice::resource_value_int(DeviceResource,
                                       uint16_t) const
 {
     return m2mdevice_stub::int_value;

--- a/test/mbedclient/utest/stub/m2mfirmware_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mfirmware_stub.cpp
@@ -82,7 +82,7 @@ bool M2MFirmware::set_resource_value(FirmwareResource,
 }
 
 bool M2MFirmware::set_resource_value(FirmwareResource,
-                                       int64_t)
+                                       int32_t)
 {
     return m2mfirmware_stub::bool_value;
 }
@@ -92,7 +92,7 @@ String M2MFirmware::resource_value_string(FirmwareResource) const
     return m2mfirmware_stub::string_value;
 }
 
-int64_t M2MFirmware::resource_value_int(FirmwareResource) const
+int32_t M2MFirmware::resource_value_int(FirmwareResource) const
 {
     return m2mfirmware_stub::int_value;
 }


### PR DESCRIPTION
@yogpan01 @anttiylitokola @kuggenhoffen 

I would like to change most of the int64 variables to int32:s. This is for few reasons:

1) Resolves http://jira.arm.com/browse/IOTCLT-496
 - other way to resolve this ticket would require either changing the current snprintf implementation to stringstream or by changing newlib-nano to more memory consuming newlib.  (arm-mbed uses newlib-nano which does not support %lld)

I would rather use implementation that uses minimal amount of memory and space, I suspect moving to std::stringstream would result in still larger included libraries

2) We do not really need int64 size variables for device objects or firmware. Considering embedded devices, using smaller variables might give speed/footprint advantages