### PR TITLE
implement itoa for int64 handling + unit-tests

### DIFF
--- a/mbed-client/m2mstring.h
+++ b/mbed-client/m2mstring.h
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef M2M_STRING_H
+#define M2M_STRING_H
+
 #include <stddef.h> // size_t
 #include <stdexcept>
+#include <stdint.h>
 
 class Test_M2MString;
 
@@ -121,4 +125,10 @@ namespace m2m
   bool
   operator<(const String&, const String&);
 
+  void reverse(char s[], uint32_t length);
+
+  uint32_t itoa_c (int64_t n, char s[]);
 } // namespace
+
+
+#endif // M2M_STRING_H

--- a/source/m2mfirmware.cpp
+++ b/source/m2mfirmware.cpp
@@ -20,6 +20,8 @@
 #include "mbed-client/m2mobjectinstance.h"
 #include "mbed-client/m2mresource.h"
 
+#define BUFFER_SIZE 21
+
 M2MFirmware* M2MFirmware::_instance = NULL;
 
 M2MFirmware* M2MFirmware::get_instance()
@@ -158,13 +160,13 @@ M2MResource* M2MFirmware::create_resource(FirmwareResource resource, int64_t val
                                                             false);
 
             if(res) {
-                char *buffer = (char*)memory_alloc(20);
+                char *buffer = (char*)memory_alloc(BUFFER_SIZE);
                 if(buffer) {
-                    int size = snprintf(buffer, 20,"%lld",(long long int)value);
-
-                    res->set_operation(operation);
-                    res->set_value((const uint8_t*)buffer,
-                                   (uint32_t)size);
+                    uint32_t size = m2m::itoa_c(value, buffer);
+                    if (size <= BUFFER_SIZE) {
+                        res->set_operation(operation);
+                        res->set_value((const uint8_t*)buffer, size);
+                    }
                     memory_free(buffer);
                 }
             }
@@ -207,11 +209,12 @@ bool M2MFirmware::set_resource_value(FirmwareResource resource,
             // If it is any of the above resource
             // set the value of the resource.
             if (check_value_range(resource, value)) {
-                char *buffer = (char*)memory_alloc(20);
+                char *buffer = (char*)memory_alloc(BUFFER_SIZE);
                 if(buffer) {
-                    int size = snprintf(buffer, 20,"%lld",(long long int)value);
-                    success = res->set_value((const uint8_t*)buffer,
-                                             (uint32_t)size);
+                    uint32_t size = m2m::itoa_c(value, buffer);
+                    if (size <= BUFFER_SIZE) {
+                        success = res->set_value((const uint8_t*)buffer, size);
+                    }
                     memory_free(buffer);
                 }
             }

--- a/source/m2mobject.cpp
+++ b/source/m2mobject.cpp
@@ -22,6 +22,8 @@
 #include "include/m2mreporthandler.h"
 #include "ns_trace.h"
 
+#define BUFFER_SIZE 10
+
 M2MObject::M2MObject(const String &object_name)
 : M2MBase(object_name,M2MBase::Dynamic),
   _max_instance_count(MAX_UNINT_16_COUNT)
@@ -43,9 +45,9 @@ M2MObject::~M2MObject()
             //Free allocated memory for object instances.
             obj = *it;
 
-            char *obj_inst_id = (char*)malloc(20);
+            char *obj_inst_id = (char*)malloc(BUFFER_SIZE);
             if(obj_inst_id) {
-                snprintf(obj_inst_id, 20,"%d",index);
+                snprintf(obj_inst_id, BUFFER_SIZE,"%d",index);
 
                 String obj_name = M2MBase::name();
                 obj_name += String("/");
@@ -117,9 +119,9 @@ bool M2MObject::remove_object_instance(uint16_t inst_id)
                 // Instance found and deleted.
                 obj = *it;
 
-                char *obj_inst_id = (char*)malloc(20);
+                char *obj_inst_id = (char*)malloc(BUFFER_SIZE);
                 if(obj_inst_id) {
-                    snprintf(obj_inst_id, 20,"%d",obj->instance_id());
+                    snprintf(obj_inst_id, BUFFER_SIZE,"%d",obj->instance_id());
 
                     String obj_name = name();
                     obj_name += String("/");
@@ -491,8 +493,8 @@ sn_coap_hdr_s* M2MObject::handle_post_request(nsdl_s *nsdl,
 
                                             obj_name = M2MBase::name();
                                             obj_name += String("/");
-                                            obj_inst_id = (char*)malloc(10);
-                                            snprintf(obj_inst_id, 10,"%d",instance_id);
+                                            obj_inst_id = (char*)malloc(BUFFER_SIZE);
+                                            snprintf(obj_inst_id, BUFFER_SIZE,"%d",instance_id);
                                             obj_name += obj_inst_id;
 
                                             coap_response->options_list_ptr->location_path_len = obj_name.length();

--- a/source/m2msecurity.cpp
+++ b/source/m2msecurity.cpp
@@ -19,7 +19,9 @@
 #include "mbed-client/m2mobject.h"
 #include "mbed-client/m2mobjectinstance.h"
 #include "mbed-client/m2mresource.h"
+#include "mbed-client/m2mstring.h"
 
+#define BUFFER_SIZE 21
 
 M2MSecurity::M2MSecurity(ServerType ser_type)
 : M2MObject(M2M_SECURITY_ID),
@@ -119,12 +121,13 @@ M2MResource* M2MSecurity::create_resource(SecurityResource resource, uint32_t va
                                                             false);
 
             if(res) {
-                char *buffer = (char*)malloc(20);
+                char *buffer = (char*)malloc(BUFFER_SIZE);
                 if(buffer) {
-                    int size = snprintf(buffer, 20,"%ld",(long int)value);
-                    res->set_operation(M2MBase::NOT_ALLOWED);
-                    res->set_value((const uint8_t*)buffer,
-                                   (uint32_t)size);
+                    uint32_t size = m2m::itoa_c(value, buffer);
+                    if (size <= BUFFER_SIZE) {
+                        res->set_operation(M2MBase::NOT_ALLOWED);
+                        res->set_value((const uint8_t*)buffer, size);
+                    }
                     free(buffer);
                 }
             }
@@ -190,11 +193,11 @@ bool M2MSecurity::set_resource_value(SecurityResource resource,
            M2MSecurity::ClientHoldOffTime == resource) {
             // If it is any of the above resource
             // set the value of the resource.
-            char *buffer = (char*)malloc(20);
+            char *buffer = (char*)malloc(BUFFER_SIZE);
             if(buffer) {
-                int size = snprintf(buffer, 20,"%ld",(long int)value);
-                success = res->set_value((const uint8_t*)buffer,
-                                         (uint32_t)size);
+                uint32_t size = m2m::itoa_c(value, buffer);
+                if (size <= BUFFER_SIZE)
+                    success = res->set_value((const uint8_t*)buffer, size);
                 free(buffer);
             }
         }

--- a/source/m2mserver.cpp
+++ b/source/m2mserver.cpp
@@ -19,7 +19,9 @@
 #include "mbed-client/m2mobject.h"
 #include "mbed-client/m2mobjectinstance.h"
 #include "mbed-client/m2mresource.h"
+#include "mbed-client/m2mstring.h"
 
+#define BUFFER_SIZE 21
 
 M2MServer::M2MServer()
 : M2MObject(M2M_SERVER_ID)
@@ -101,10 +103,12 @@ M2MResource* M2MServer::create_resource(ServerResource resource, uint32_t value)
             if(res) {
                 res->set_operation(M2MBase::GET_PUT_POST_ALLOWED);
                 // If resource is created then set the value.
-                char *buffer = (char*)malloc(20);
+                char *buffer = (char*)malloc(BUFFER_SIZE);
                 if(buffer) {
-                    int size = snprintf(buffer, 20,"%ld",(long int)value);
-                    res->set_value((const uint8_t*)buffer,(uint32_t)size);
+                    uint32_t size = m2m::itoa_c(value, buffer);
+                    if (size <= BUFFER_SIZE) {
+                        res->set_value((const uint8_t*)buffer, size);
+                    }
                     free(buffer);
                 }
             }
@@ -185,11 +189,11 @@ bool M2MServer::set_resource_value(ServerResource resource,
            M2MServer::NotificationStorage == resource) {
             // If it is any of the above resource
             // set the value of the resource.
-            char *buffer = (char*)malloc(20);
+            char *buffer = (char*)malloc(BUFFER_SIZE);
             if(buffer) {
-                int size = snprintf(buffer, 20,"%ld",(long int)value);
-                success = res->set_value((const uint8_t*)buffer,
-                                         (uint32_t)size);
+                uint32_t size = m2m::itoa_c(value, buffer);
+                if (size <= BUFFER_SIZE)
+                    success = res->set_value((const uint8_t*)buffer, size);
                 free(buffer);
             }
         }

--- a/source/m2mstring.cpp
+++ b/source/m2mstring.cpp
@@ -363,4 +363,39 @@ namespace m2m {
     return strcmp( s1.c_str(), s2.c_str() ) < 0;
   }
 
+  void reverse(char s[], uint32_t length)
+  {
+      uint32_t i, j;
+      char c;
+
+      for (i = 0, j = length-1; i<j; i++, j--) {
+          c = s[i];
+          s[i] = s[j];
+          s[j] = c;
+      }
+  }
+
+  uint32_t itoa_c (int64_t n, char s[])
+  {
+      int64_t sign;
+      uint32_t i;
+
+      if ((sign = n) < 0)
+          n = -n;
+
+      i = 0;
+
+      do {
+          s[i++] = n % 10 + '0';
+      }
+      while ((n /= 10) > 0);
+
+      if (sign < 0)
+          s[i++] = '-';
+
+      s[i] = '\0';
+
+      m2m::reverse(s, i);
+      return i;
+  }
 } // namespace

--- a/source/m2mtlvdeserializer.cpp
+++ b/source/m2mtlvdeserializer.cpp
@@ -19,6 +19,8 @@
 #include "include/nsdllinker.h"
 #include "ns_trace.h"
 
+#define BUFFER_SIZE 10
+
 M2MTLVDeserializer::M2MTLVDeserializer()
 {
 }
@@ -188,9 +190,9 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(uint8_t *tlv
         if(!found) {
             if(M2MTLVDeserializer::Post == operation) {
                 //Create a new Resource
-                char *buffer = (char*)malloc(10);
+                char *buffer = (char*)malloc(BUFFER_SIZE);
                 if(buffer) {
-                    snprintf(buffer,10, "%d",til->_id);
+                    snprintf(buffer, BUFFER_SIZE, "%d",til->_id);
                     String id(buffer);
                     M2MResource *resource = object_instance.create_dynamic_resource(id,"",M2MResourceInstance::INTEGER,true,false);
                     if(resource) {

--- a/test/mbedclient/utest/m2mstring/m2mstringtest.cpp
+++ b/test/mbedclient/utest/m2mstring/m2mstringtest.cpp
@@ -145,3 +145,13 @@ TEST(M2MString, test_operator_lt)
 {
     m2m_string->test_operator_lt();
 }
+
+TEST(M2MString, test_reverse)
+{
+    m2m_string->test_reverse();
+}
+
+TEST(M2MString, test_itoa_c)
+{
+    m2m_string->test_itoa_c();
+}

--- a/test/mbedclient/utest/m2mstring/test_m2mstring.cpp
+++ b/test/mbedclient/utest/m2mstring/test_m2mstring.cpp
@@ -15,7 +15,8 @@
  */
 #include "CppUTest/TestHarness.h"
 #include "test_m2mstring.h"
-
+#include <stdio.h>
+#include <string.h>
 
 Test_M2MString::Test_M2MString()
 {
@@ -252,4 +253,44 @@ void Test_M2MString::test_operator_lt()
     CHECK( (s < s1 ) == true);
     CHECK( (s1 < s2 ) == false);
 }
+void Test_M2MString::test_reverse()
+{
+    char string1[] = "123";
+    char string2[] = "321";
+    m2m::reverse(string1, strlen(string1));
+    char string3[] = "9223372036854775807";
+    char string4[] = "7085774586302733229";
+    m2m::reverse(string3, strlen(string3));
 
+    CHECK(strcmp(string1, string2) == 0);
+    CHECK(strcmp(string3, string4) == 0);
+}
+void Test_M2MString::test_itoa_c()
+{
+    int64_t value1 = 0;
+    char* string1 = "0";
+    int64_t value2 = -10;
+    char* string2 = "-10";
+    int64_t value3 = 10000;
+    char* string3 = "10000";
+    int64_t value4 = 9223372036854775807;
+    char* string4 = "9223372036854775807";
+    int64_t value5 = -9223372036854775807;
+    char* string5 = "-9223372036854775807";
+
+    char *buffer = (char*)malloc(21);
+
+    if(buffer) {
+        m2m::itoa_c(value1, buffer);
+        CHECK(strcmp(string1, buffer) == 0);
+        m2m::itoa_c(value2, buffer);
+        CHECK(strcmp(string2, buffer) == 0);
+        m2m::itoa_c(value3, buffer);
+        CHECK(strcmp(string3, buffer) == 0);
+        m2m::itoa_c(value4, buffer);
+        CHECK(strcmp(string4, buffer) == 0);
+        m2m::itoa_c(value5, buffer);
+        CHECK(strcmp(string5, buffer) == 0);
+        free(buffer);
+    }
+}

--- a/test/mbedclient/utest/m2mstring/test_m2mstring.h
+++ b/test/mbedclient/utest/m2mstring/test_m2mstring.h
@@ -47,8 +47,9 @@ public:
     void test_append();
     void test_compare();
     void test_find_last_of();
-
     void test_operator_lt();
+    void test_reverse();
+    void test_itoa_c();
 
     String* str;
 };

--- a/test/mbedclient/utest/stub/m2mstring_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mstring_stub.cpp
@@ -363,4 +363,38 @@ namespace m2m {
     return strcmp( s1.c_str(), s2.c_str() ) < 0;
   }
 
+  void reverse(char s[], uint32_t length)
+  {
+    uint32_t i, j;
+    char c;
+
+    for (i = 0, j = length-1; i<j; i++, j--) {
+        c = s[i];
+        s[i] = s[j];
+        s[j] = c;
+    }
+  }
+
+  uint32_t itoa_c (int64_t n, char s[])
+  {
+      int64_t sign;
+      uint32_t i;
+
+      if ((sign = n) < 0)
+          n = -n;
+
+      i = 0;
+
+      do {
+          s[i++] = n % 10 + '0';
+      }
+      while ((n /= 10) > 0);
+
+      if (sign < 0)
+          s[i++] = '-';
+
+      s[i] = '\0';
+      m2m::reverse(s, i);
+      return i;
+  }
 } // namespace


### PR DESCRIPTION
Could you check this? @yogpan01 @anttiylitokola @kuggenhoffen 

I changed most snprintf functions, only leaving some which handled only small ints.

I defined BUFFER_SIZE seperately for most files, also increasing it for large buffers 20->21. The 20 was a bit too small for maximum int64 values.

New unit-tests also included in this commit.