### PR TITLE
When observing object, notification must contain only changed object …

### DIFF
--- a/mbed-client/m2mbase.h
+++ b/mbed-client/m2mbase.h
@@ -323,7 +323,7 @@ public:
                                                M2MObservationHandler *observation_handler = NULL);
 protected : // from M2MReportObserver
 
-    virtual void observation_to_be_sent();
+    virtual void observation_to_be_sent(uint16_t obj_instance_id);
 
 protected:
 

--- a/mbed-client/m2mobject.h
+++ b/mbed-client/m2mobject.h
@@ -148,7 +148,7 @@ public:
 
 protected :
 
-     virtual void notification_update();
+     virtual void notification_update(uint16_t obj_instance_id);
 
 private:
 

--- a/mbed-client/m2mobjectinstance.h
+++ b/mbed-client/m2mobjectinstance.h
@@ -25,7 +25,7 @@ typedef Vector<M2MResourceInstance *> M2MResourceInstanceList;
 
 class M2MObjectCallback {
 public:
-    virtual void notification_update() = 0;
+    virtual void notification_update(uint16_t obj_instance_id) = 0;
 };
 
 /**

--- a/mbed-client/m2mobservationhandler.h
+++ b/mbed-client/m2mobservationhandler.h
@@ -34,11 +34,13 @@ class M2MObservationHandler
     /**
      * @brief Observation callback to be sent to the
      * server due to a change in a parameter under observation.
-     * @param object, Observed object whose information
+     * @param object, Observed object whose information needs to be sent
      * @param obs_number, Observation number
-     * needs to be sent.
+     * @param obj_instance_id, Object instance id to be sent
      */
-    virtual void observation_to_be_sent(M2MBase *object, uint16_t obs_number) = 0;
+    virtual void observation_to_be_sent(M2MBase *object,
+                                        uint16_t obs_number,
+                                        uint16_t obj_instance_id) = 0;
 
     /**
      * @brief Callback for deleting an NSDL resource.

--- a/mbed-client/m2mreportobserver.h
+++ b/mbed-client/m2mreportobserver.h
@@ -16,6 +16,8 @@
 #ifndef M2MREPORTOBSERVER_H
 #define M2MREPORTOBSERVER_H
 
+#include <inttypes.h>
+
 //FORWARD DECLARATION
 class M2MResourceInstance;
 
@@ -32,9 +34,9 @@ class M2MReportObserver
     /**
      * @brief Observation callback to be sent to the
      * server due to a change in the observed parameter.
+     * @param obj_instance_id, Object instance id that has changed
      */
-    virtual void observation_to_be_sent() = 0;
-
+    virtual void observation_to_be_sent(uint16_t obj_instance_id) = 0;
 };
 
 #endif // M2MREPORTOBSERVER_H

--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -210,7 +210,7 @@ protected: // from M2MTimerObserver
 
 protected: // from M2MObservationHandler
 
-    virtual void observation_to_be_sent(M2MBase *object, uint16_t obs_number);
+    virtual void observation_to_be_sent(M2MBase *object, uint16_t obs_number, uint16_t obj_instance_id);
 
     virtual void resource_to_be_deleted(const String &resource_name);
 
@@ -263,7 +263,7 @@ private:
 
     M2MInterface::Error interface_error(sn_coap_hdr_s *coap_header);
 
-    void send_object_observation(M2MObject *object, uint16_t obs_number);
+    void send_object_observation(M2MObject *object, uint16_t obs_number, uint16_t obj_instance_id);
 
     void send_object_instance_observation(M2MObjectInstance *object_instance, uint16_t obs_number);
 

--- a/source/include/m2mreporthandler.h
+++ b/source/include/m2mreporthandler.h
@@ -78,8 +78,9 @@ public:
 
     /**
      * @brief Sets notification trigger.
+     * @param obj_instance_id, Object instance id that has changed
      */
-    void set_notification_trigger();
+    void set_notification_trigger(uint16_t obj_instance_id = 0);
 
     /**
      * @brief Parses the received query for notification
@@ -173,6 +174,7 @@ private:
     float                       _last_value;    
     uint8_t                     _attribute_state;
     bool                        _notify;
+    uint16_t                    _obj_instance_id;
 
 friend class Test_M2MReportHandler;
 

--- a/source/m2mbase.cpp
+++ b/source/m2mbase.cpp
@@ -315,12 +315,14 @@ bool M2MBase::handle_observation_attribute(char *&query)
     return success;
 }
 
-void M2MBase::observation_to_be_sent()
+void M2MBase::observation_to_be_sent(uint16_t obj_instance_id)
 {
     //TODO: Move this to M2MResourceInstance
     if(_observation_handler) {
        _observation_number++;
-       _observation_handler->observation_to_be_sent(this, _observation_number);
+       _observation_handler->observation_to_be_sent(this,
+                                                    _observation_number,
+                                                    obj_instance_id);
     }
 }
 

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -717,13 +717,13 @@ void M2MNsdlInterface::timer_expired(M2MTimerObserver::Type type)
     }
 }
 
-void M2MNsdlInterface::observation_to_be_sent(M2MBase *object, uint16_t obs_number)
+void M2MNsdlInterface::observation_to_be_sent(M2MBase *object, uint16_t obs_number, uint16_t obj_instance_id)
 {
     tr_debug("M2MNsdlInterface::observation_to_be_sent()");
     if(object) {
         M2MBase::BaseType type = object->base_type();
         if(type == M2MBase::Object) {
-            send_object_observation((M2MObject*)object, obs_number);
+            send_object_observation((M2MObject*)object, obs_number, obj_instance_id);
         } else if(type == M2MBase::ObjectInstance) {
             send_object_instance_observation((M2MObjectInstance*)object, obs_number);
         } else if(type == M2MBase::Resource) {
@@ -1260,9 +1260,10 @@ M2MInterface::Error M2MNsdlInterface::interface_error(sn_coap_hdr_s *coap_header
 }
 
 void M2MNsdlInterface::send_object_observation(M2MObject *object,
-                                               uint16_t obs_number)
+                                               uint16_t obs_number,
+                                               uint16_t obj_instance_id)
 {
-    tr_debug("M2MNsdlInterface::send_object_observation");
+    tr_debug("M2MNsdlInterface::send_object_observation, instance id: %d", obj_instance_id);
     if(object) {
         uint8_t *value = 0;
         uint32_t length = 0;
@@ -1280,10 +1281,16 @@ void M2MNsdlInterface::send_object_observation(M2MObject *object,
             *(observation_number) = obs_number & 0x00FF;
         }
 
-        M2MTLVSerializer *serializer = new M2MTLVSerializer();
-        if(serializer) {
-            value = serializer->serialize(object->instances(), length);
-            delete serializer;
+        M2MObjectInstance* obj_instance = object->object_instance(obj_instance_id);
+        if (obj_instance){
+            M2MObjectInstanceList list;
+            list.push_back(obj_instance);
+            M2MTLVSerializer *serializer = new M2MTLVSerializer();
+            if(serializer) {
+                value = serializer->serialize(list, length);
+                delete serializer;
+            }
+            list.clear();
         }
 
         object->get_observation_token(token,token_length);

--- a/source/m2mobject.cpp
+++ b/source/m2mobject.cpp
@@ -554,12 +554,12 @@ sn_coap_hdr_s* M2MObject::handle_post_request(nsdl_s *nsdl,
     return coap_response;
 }
 
-void M2MObject::notification_update()
+void M2MObject::notification_update(uint16_t obj_instance_id)
 {
     tr_debug("M2MObject::notification_update");
     M2MReportHandler *report_handler = M2MBase::report_handler();
     if(report_handler && is_observable()) {
-        report_handler->set_notification_trigger();
+        report_handler->set_notification_trigger(obj_instance_id);
     }
 }
 

--- a/source/m2mobjectinstance.cpp
+++ b/source/m2mobjectinstance.cpp
@@ -742,7 +742,7 @@ sn_coap_hdr_s* M2MObjectInstance::handle_post_request(nsdl_s *nsdl,
 void M2MObjectInstance::notification_update(M2MBase::Observation observation_level)
 {
     if(M2MBase::O_Attribute == observation_level) {
-        _object_callback.notification_update();
+        _object_callback.notification_update(instance_id());
     } else {
         M2MReportHandler *report_handler = M2MBase::report_handler();
         if(report_handler && is_observable()) {

--- a/source/m2mreporthandler.cpp
+++ b/source/m2mreporthandler.cpp
@@ -37,7 +37,8 @@ M2MReportHandler::M2MReportHandler(M2MReportObserver &observer)
   _current_value(0.0f),
   _last_value(0.0f),
   _attribute_state(0),
-  _notify(false)
+  _notify(false),
+  _obj_instance_id(0)
 {
     tr_debug("M2MReportHandler::M2MReportHandler()");
 }
@@ -93,9 +94,10 @@ void M2MReportHandler::set_value(float value)
     }
 }
 
-void M2MReportHandler::set_notification_trigger()
+void M2MReportHandler::set_notification_trigger(uint16_t obj_instance_id)
 {
     tr_debug("M2MReportHandler::set_notification_trigger()");
+    _obj_instance_id = obj_instance_id;
     _current_value = 0.0f;
     _last_value = 1.0f;    
     schedule_report();
@@ -294,7 +296,7 @@ void M2MReportHandler::report()
         _pmin_exceeded = false;
         _pmax_exceeded = false;
         _notify = false;
-        _observer.observation_to_be_sent();
+        _observer.observation_to_be_sent(_obj_instance_id);
         if (_pmax_timer) {
             _pmax_timer->stop_timer();
         }
@@ -302,7 +304,7 @@ void M2MReportHandler::report()
     else {
         if (_pmax_exceeded) {
             tr_debug("M2MReportHandler::report()- send with PMAX");
-            _observer.observation_to_be_sent();
+            _observer.observation_to_be_sent(_obj_instance_id);
         }
         else {
             tr_debug("M2MReportHandler::report()- no need to send");

--- a/test/mbedclient/utest/m2mbase/test_m2mbase.cpp
+++ b/test/mbedclient/utest/m2mbase/test_m2mbase.cpp
@@ -27,7 +27,7 @@ public:
 
     Handler(){}
     ~Handler(){}
-    void observation_to_be_sent(M2MBase *, uint16_t){
+    void observation_to_be_sent(M2MBase *, uint16_t, uint16_t){
         visited = true;
     }
     void resource_to_be_deleted(const String &){visited=true;}
@@ -43,7 +43,7 @@ public:
     Observer(){}
     ~Observer(){}
 
-    void observation_to_be_sent(){}
+    void observation_to_be_sent(uint16_t){}
 };
 
 Test_M2MBase::Test_M2MBase()
@@ -406,13 +406,13 @@ void Test_M2MBase::test_observation_to_be_sent()
 {
     Handler handler;
 
-    observation_to_be_sent();
+    observation_to_be_sent(0);
     CHECK(handler.visited == false);
 
     bool test = true;
     set_under_observation(test,&handler);
 
-    observation_to_be_sent();
+    observation_to_be_sent(0);
 
     CHECK(handler.visited == true);
 }

--- a/test/mbedclient/utest/m2mdevice/test_m2mdevice.cpp
+++ b/test/mbedclient/utest/m2mdevice/test_m2mdevice.cpp
@@ -27,7 +27,7 @@ public:
 
     Callback(){}
     ~Callback(){}
-    void notification_update() {
+    void notification_update(uint16_t obj_instance_id) {
         visited = true;
     }
 

--- a/test/mbedclient/utest/m2mfirmware/test_m2mfirmware.cpp
+++ b/test/mbedclient/utest/m2mfirmware/test_m2mfirmware.cpp
@@ -27,7 +27,7 @@ public:
 
     Callback(){}
     ~Callback(){}
-    void notification_update() {
+    void notification_update(uint16_t obj_instance_id) {
         visited = true;
     }
 

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
@@ -1156,32 +1156,28 @@ void Test_M2MNsdlInterface::test_observation_to_be_sent()
     m2mresourceinstance_stub::base_type = M2MBase::Resource;
 
     //CHECK if nothing crashes
-    nsdl->observation_to_be_sent(res2, 1);
+    nsdl->observation_to_be_sent(res2, 1, 0);
 
     m2mresource_stub::list.clear();
     m2mresource_stub::int_value = 0;
 
     //CHECK if nothing crashes
-    nsdl->observation_to_be_sent(res, 500);
+    nsdl->observation_to_be_sent(res, 500, 0);
 
     M2MObjectInstance *object_instance = new M2MObjectInstance("name",*object);
-
-    m2mobject_stub::int_value = 1;
-    m2mobject_stub::instance_list.push_back(object_instance);
-
+    m2mobject_stub::int_value = 1;    
     m2mobject_stub::base_type = M2MBase::Object;
-
+    m2mobject_stub::inst = object_instance;
     m2mobjectinstance_stub::resource_list.push_back(res);
-
     nsdl->_object_list.push_back(object);
 
     //CHECK if nothing crashes
-    nsdl->observation_to_be_sent(object, 1);
-    nsdl->observation_to_be_sent(object, 500);
+    nsdl->observation_to_be_sent(object, 1, 0);
+    nsdl->observation_to_be_sent(object, 500, 0);
 
     //CHECK if nothing crashes
-    nsdl->observation_to_be_sent(object_instance, 1);
-    nsdl->observation_to_be_sent(object_instance, 500);
+    nsdl->observation_to_be_sent(object_instance, 1, 0);
+    nsdl->observation_to_be_sent(object_instance, 500, 0);
 
     delete owned;
     owned = NULL;

--- a/test/mbedclient/utest/m2mobject/test_m2mobject.cpp
+++ b/test/mbedclient/utest/m2mobject/test_m2mobject.cpp
@@ -27,7 +27,7 @@ class TestReportObserver :  public M2MReportObserver{
 public :
     TestReportObserver() {}
     ~TestReportObserver() {}
-    void observation_to_be_sent(){ }
+    void observation_to_be_sent(uint16_t){ }
 };
 
 class Handler : public M2MObservationHandler {
@@ -36,7 +36,7 @@ public:
 
     Handler(){}
     ~Handler(){}
-    void observation_to_be_sent(M2MBase *, uint16_t){
+    void observation_to_be_sent(M2MBase *, uint16_t, uint16_t){
         visited = true;
     }
     void resource_to_be_deleted(const String &){visited=true;}
@@ -859,7 +859,7 @@ void Test_M2MObject::test_notification_update()
     m2mbase_stub::report = new M2MReportHandler(obs);
     m2mbase_stub::bool_value = true;
 
-    object->notification_update();
+    object->notification_update(0);
 
     delete m2mbase_stub::report;
     m2mbase_stub::report = NULL;

--- a/test/mbedclient/utest/m2mobjectinstance/test_m2mobjectinstance.cpp
+++ b/test/mbedclient/utest/m2mobjectinstance/test_m2mobjectinstance.cpp
@@ -32,7 +32,7 @@ public:
 
     Handler(){}
     ~Handler(){}
-    void observation_to_be_sent(M2MBase *, uint16_t){
+    void observation_to_be_sent(M2MBase *, uint16_t, uint16_t){
         visited = true;
     }
     void resource_to_be_deleted(const String &){visited=true;}
@@ -47,7 +47,7 @@ class TestReportObserver :  public M2MReportObserver{
 public :
     TestReportObserver() {}
     ~TestReportObserver() {}
-    void observation_to_be_sent(){ }
+    void observation_to_be_sent(uint16_t){ }
 };
 
 class Callback : public M2MObjectCallback {
@@ -56,7 +56,7 @@ public:
 
     Callback(){}
     ~Callback(){}
-    void notification_update() {
+    void notification_update(uint16_t obj_instance_id) {
         visited = true;
     }
 

--- a/test/mbedclient/utest/m2mreporthandler/test_m2mreporthandler.cpp
+++ b/test/mbedclient/utest/m2mreporthandler/test_m2mreporthandler.cpp
@@ -26,7 +26,7 @@ public:
 
     Observer(){}
     virtual ~Observer(){}
-    void observation_to_be_sent(){
+    void observation_to_be_sent(uint16_t){
         visited = true;
     }
     bool visited;

--- a/test/mbedclient/utest/m2mresource/test_m2mresource.cpp
+++ b/test/mbedclient/utest/m2mresource/test_m2mresource.cpp
@@ -28,7 +28,7 @@ class TestReportObserver :  public M2MReportObserver{
 public :
     TestReportObserver() {}
     ~TestReportObserver() {}
-    void observation_to_be_sent(){ }
+    void observation_to_be_sent(uint16_t){ }
 };
 
 
@@ -61,7 +61,7 @@ public:
 
     Handler(){}
     ~Handler(){}
-    void observation_to_be_sent(M2MBase *, uint16_t){
+    void observation_to_be_sent(M2MBase *, uint16_t,uint16_t){
         visited = true;
     }
     void resource_to_be_deleted(const String &){visited=true;}

--- a/test/mbedclient/utest/m2mresourceinstance/test_m2mresourceinstance.cpp
+++ b/test/mbedclient/utest/m2mresourceinstance/test_m2mresourceinstance.cpp
@@ -249,14 +249,14 @@ void Test_M2MResourceInstance::test_set_value()
     m2mbase_stub::observation_level_value = M2MBase::O_Attribute;
     resource_instance->_resource_type = M2MResourceInstance::INTEGER;
     m2mbase_stub::mode_value = M2MBase::Dynamic;
-    CHECK(resource_instance->set_value(value2,(u_int32_t)sizeof(value2)) == true);
-
-
     ResourceCallback *resource_cb = new ResourceCallback();
     resource_instance->set_resource_observer(resource_cb);
-
     CHECK(resource_instance->set_value(value2,(u_int32_t)sizeof(value2)) == true);
     CHECK(resource_cb->visited == true);
+
+
+    resource_instance->set_resource_observer(NULL);
+    CHECK(resource_instance->set_value(value3,(u_int32_t)sizeof(value3)) == true);
 
     m2mbase_stub::observation_level_value = M2MBase::OI_Attribute;
 

--- a/test/mbedclient/utest/m2mresourceinstance/test_m2mresourceinstance.cpp
+++ b/test/mbedclient/utest/m2mresourceinstance/test_m2mresourceinstance.cpp
@@ -36,7 +36,7 @@ class TestReportObserver :  public M2MReportObserver{
 public :
     TestReportObserver() {}
     ~TestReportObserver() {}
-    void observation_to_be_sent(){ }
+    void observation_to_be_sent(uint16_t){ }
 };
 
 class ResourceCallback : public M2MResourceCallback {
@@ -59,7 +59,7 @@ public:
 
     Handler(){}
     ~Handler(){}
-    void observation_to_be_sent(M2MBase *, uint16_t){
+    void observation_to_be_sent(M2MBase *, uint16_t, uint16_t){
         visited = true;
     }
     void resource_to_be_deleted(const String &){visited=true;}
@@ -250,12 +250,13 @@ void Test_M2MResourceInstance::test_set_value()
     resource_instance->_resource_type = M2MResourceInstance::INTEGER;
     m2mbase_stub::mode_value = M2MBase::Dynamic;
     CHECK(resource_instance->set_value(value2,(u_int32_t)sizeof(value2)) == true);
-    //CHECK(resource_cb->visited == true);
+
 
     ResourceCallback *resource_cb = new ResourceCallback();
     resource_instance->set_resource_observer(resource_cb);
 
     CHECK(resource_instance->set_value(value2,(u_int32_t)sizeof(value2)) == true);
+    CHECK(resource_cb->visited == true);
 
     m2mbase_stub::observation_level_value = M2MBase::OI_Attribute;
 

--- a/test/mbedclient/utest/m2msecurity/test_m2msecurity.cpp
+++ b/test/mbedclient/utest/m2msecurity/test_m2msecurity.cpp
@@ -27,7 +27,7 @@ public:
 
     Callback(){}
     ~Callback(){}
-    void notification_update() {
+    void notification_update(uint16_t obj_instance_id) {
         visited = true;
     }
 

--- a/test/mbedclient/utest/m2mserver/test_m2mserver.cpp
+++ b/test/mbedclient/utest/m2mserver/test_m2mserver.cpp
@@ -27,7 +27,7 @@ public:
 
     Callback(){}
     ~Callback(){}
-    void notification_update() {
+    void notification_update(uint16_t obj_instance_id) {
         visited = true;
     }
 

--- a/test/mbedclient/utest/stub/m2mbase_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mbase_stub.cpp
@@ -201,7 +201,7 @@ bool M2MBase::handle_observation_attribute(char *&query)
     return m2mbase_stub::bool_value;
 }
 
-void M2MBase::observation_to_be_sent()
+void M2MBase::observation_to_be_sent(uint16_t obj_instance_id)
 {
 }
 

--- a/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
@@ -138,7 +138,7 @@ void M2MNsdlInterface::timer_expired(M2MTimerObserver::Type)
 {
 }
 
-void M2MNsdlInterface::observation_to_be_sent(M2MBase *, uint16_t obs_number)
+void M2MNsdlInterface::observation_to_be_sent(M2MBase *, uint16_t, uint16_t)
 {
 }
 

--- a/test/mbedclient/utest/stub/m2mobject_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mobject_stub.cpp
@@ -112,6 +112,6 @@ sn_coap_hdr_s* M2MObject::handle_post_request(nsdl_s *,
     return m2mobject_stub::header;
 }
 
-void M2MObject::notification_update()
+void M2MObject::notification_update(uint16_t obj_instance_id)
 {
 }

--- a/test/mbedclient/utest/stub/m2mreporthandler_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mreporthandler_stub.cpp
@@ -52,7 +52,7 @@ void M2MReportHandler::timer_expired(M2MTimerObserver::Type )
 {
 }
 
-void M2MReportHandler::set_notification_trigger()
+void M2MReportHandler::set_notification_trigger(uint16_t)
 {
 }
 


### PR DESCRIPTION
…instance

 * Fix error IOTCLT-526 - Object level observation is not sending individual notification for each changed object instance values