### PR TITLE
Fix for IOTCLT-525.

### DIFF
--- a/mbed-client/m2mbase.h
+++ b/mbed-client/m2mbase.h
@@ -321,6 +321,19 @@ public:
     virtual sn_coap_hdr_s* handle_post_request(nsdl_s *nsdl,
                                                sn_coap_hdr_s *received_coap_header,
                                                M2MObservationHandler *observation_handler = NULL);
+
+    /**
+     * @brief Sets whether this resource will be published to server or not.
+     * @param register_uri, True sets the resource as part of registration message.
+     */
+    virtual void set_register_uri( bool register_uri);
+
+    /**
+     * @brief Returns whether this resource will be published to server or not.
+     * @return True if resource is part of registration message else false.
+     */
+    virtual bool register_uri();
+
 protected : // from M2MReportObserver
 
     virtual void observation_to_be_sent(uint16_t obj_instance_id);
@@ -391,6 +404,7 @@ private:
     uint16_t                    _observation_number;
     uint8_t                     *_token;
     uint8_t                     _token_length;
+    bool                        _register_uri;
 
 friend class Test_M2MBase;
 

--- a/mbed-client/m2mdevice.h
+++ b/mbed-client/m2mdevice.h
@@ -234,6 +234,8 @@ private:
 
     bool check_value_range(DeviceResource resource, const int64_t value) const;
 
+    uint8_t* convert_integer_to_array(int64_t value, uint32_t &size);
+
 private :
 
     M2MObjectInstance*    _device_instance;     //Not owned

--- a/mbed-client/m2mstring.h
+++ b/mbed-client/m2mstring.h
@@ -110,6 +110,10 @@ namespace m2m
 
     int     find_last_of(char c) const;
 
+    static uint8_t* convert_integer_to_array(int64_t value, uint32_t &size);
+
+    static int64_t convert_array_to_integer(uint8_t *value, uint32_t size);
+
   private:
     // reallocate the internal memory
     void  new_realloc( size_type n);

--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/ARMmbed/mbed-client",
   "license": "Apache-2.0",
   "dependencies": {
-    "mbed-client-c": "^1.1.0"
+    "mbed-client-c": "^2.0.0"
   },
   "targetDependencies": {
     "arm": {

--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -236,7 +236,7 @@ private:
                                         const String &object_name = "",
                                         bool multiple_instances = false);
 
-    bool create_nsdl_resource(M2MBase *base, const String &name = "");
+    bool create_nsdl_resource(M2MBase *base, const String &name = "", bool publish_uri = true);
 
     String coap_to_string(uint8_t *coap_data_ptr,
                           int coap_data_ptr_length);

--- a/source/m2mbase.cpp
+++ b/source/m2mbase.cpp
@@ -37,6 +37,7 @@ M2MBase& M2MBase::operator=(const M2MBase& other)
         _observation_number = other._observation_number;
         _observation_level = other._observation_level;
         _observation_handler = other._observation_handler;
+        _register_uri = other._register_uri;
 
         if(_token) {
             free(_token);
@@ -79,6 +80,7 @@ M2MBase::M2MBase(const M2MBase& other) :
     _observation_handler = other._observation_handler;
     _observation_number = other._observation_number;
     _observation_level = other._observation_level;
+    _register_uri = other._register_uri;
 
     _token_length = other._token_length;
     if(other._token) {
@@ -107,7 +109,8 @@ M2MBase::M2MBase(const String & resource_name,
   _observable(false),
   _observation_number(0),
   _token(NULL),
-  _token_length(0)
+  _token_length(0),
+  _register_uri(true)
 {
     if(is_integer(_name) && _name.size() <= MAX_ALLOWED_STRING_LENGTH) {
         _name_id = strtoul(_name.c_str(), NULL, 10);
@@ -391,6 +394,16 @@ M2MReportHandler* M2MBase::report_handler()
 M2MObservationHandler* M2MBase::observation_handler()
 {
     return _observation_handler;
+}
+
+void M2MBase::set_register_uri( bool register_uri)
+{
+    _register_uri = register_uri;
+}
+
+bool M2MBase::register_uri()
+{
+    return _register_uri;
 }
 
 bool M2MBase::is_integer(const String &value)

--- a/source/m2mdevice.cpp
+++ b/source/m2mdevice.cpp
@@ -45,11 +45,12 @@ M2MDevice::M2MDevice()
 : M2MObject(M2M_DEVICE_ID)
 {
     M2MBase::set_register_uri(false);
+
     _device_instance = M2MObject::create_object_instance();
+    _device_instance->set_operation(M2MBase::GET_ALLOWED);
 
     if(_device_instance) {
-        _device_instance->set_coap_content_type(COAP_CONTENT_OMA_TLV_TYPE);
-
+        _device_instance->set_coap_content_type(COAP_CONTENT_OMA_TLV_TYPE);        
         M2MResource* res = _device_instance->create_dynamic_resource(DEVICE_REBOOT,
                                                                      OMA_RESOURCE_TYPE,
                                                                      M2MResourceInstance::OPAQUE,

--- a/source/m2mfirmware.cpp
+++ b/source/m2mfirmware.cpp
@@ -45,6 +45,7 @@ M2MFirmware::M2MFirmware()
 {
     _firmware_instance = M2MObject::create_object_instance();
     if(_firmware_instance) {
+        _firmware_instance->set_operation(M2MBase::GET_ALLOWED);
         create_mandatory_resources();
     }
 }

--- a/source/m2mfirmware.cpp
+++ b/source/m2mfirmware.cpp
@@ -160,14 +160,12 @@ M2MResource* M2MFirmware::create_resource(FirmwareResource resource, int64_t val
                                                             false);
 
             if(res) {
-                char *buffer = (char*)memory_alloc(BUFFER_SIZE);
+                uint32_t size = 0;
+                uint8_t* buffer = String::convert_integer_to_array(value, size);
+                res->set_value(buffer, size);
+                res->set_operation(operation);
                 if(buffer) {
-                    uint32_t size = m2m::itoa_c(value, buffer);
-                    if (size <= BUFFER_SIZE) {
-                        res->set_operation(operation);
-                        res->set_value((const uint8_t*)buffer, size);
-                    }
-                    memory_free(buffer);
+                    free(buffer);
                 }
             }
         }
@@ -209,13 +207,11 @@ bool M2MFirmware::set_resource_value(FirmwareResource resource,
             // If it is any of the above resource
             // set the value of the resource.
             if (check_value_range(resource, value)) {
-                char *buffer = (char*)memory_alloc(BUFFER_SIZE);
+                uint32_t size = 0;
+                uint8_t* buffer = String::convert_integer_to_array(value, size);
+                success = res->set_value(buffer, size);
                 if(buffer) {
-                    uint32_t size = m2m::itoa_c(value, buffer);
-                    if (size <= BUFFER_SIZE) {
-                        success = res->set_value((const uint8_t*)buffer, size);
-                    }
-                    memory_free(buffer);
+                    free(buffer);
                 }
             }
         }
@@ -372,7 +368,7 @@ int64_t M2MFirmware::resource_value_int(FirmwareResource resource) const
             uint32_t length = 0;
             res->get_value(buffer,length);
             if(buffer) {
-                value = atoi((const char*)buffer);
+                value = String::convert_array_to_integer(buffer,length);
                 free(buffer);
             }
         }

--- a/source/m2msecurity.cpp
+++ b/source/m2msecurity.cpp
@@ -121,13 +121,11 @@ M2MResource* M2MSecurity::create_resource(SecurityResource resource, uint32_t va
                                                             false);
 
             if(res) {
-                char *buffer = (char*)malloc(BUFFER_SIZE);
+                uint32_t size = 0;
+                uint8_t* buffer = String::convert_integer_to_array(value, size);
+                res->set_operation(M2MBase::NOT_ALLOWED);
+                res->set_value(buffer, size);
                 if(buffer) {
-                    uint32_t size = m2m::itoa_c(value, buffer);
-                    if (size <= BUFFER_SIZE) {
-                        res->set_operation(M2MBase::NOT_ALLOWED);
-                        res->set_value((const uint8_t*)buffer, size);
-                    }
                     free(buffer);
                 }
             }
@@ -193,11 +191,10 @@ bool M2MSecurity::set_resource_value(SecurityResource resource,
            M2MSecurity::ClientHoldOffTime == resource) {
             // If it is any of the above resource
             // set the value of the resource.
-            char *buffer = (char*)malloc(BUFFER_SIZE);
+            uint32_t size = 0;
+            uint8_t* buffer = String::convert_integer_to_array(value, size);
+            success = res->set_value(buffer, size);
             if(buffer) {
-                uint32_t size = m2m::itoa_c(value, buffer);
-                if (size <= BUFFER_SIZE)
-                    success = res->set_value((const uint8_t*)buffer, size);
                 free(buffer);
             }
         }
@@ -280,7 +277,7 @@ uint32_t M2MSecurity::resource_value_int(SecurityResource resource) const
             uint32_t length = 0;
             res->get_value(buffer,length);
             if(buffer) {
-                value = atoi((const char*)buffer);
+                value = String::convert_array_to_integer(buffer,length);
                 free(buffer);
             }
         }

--- a/source/m2mserver.cpp
+++ b/source/m2mserver.cpp
@@ -103,12 +103,10 @@ M2MResource* M2MServer::create_resource(ServerResource resource, uint32_t value)
             if(res) {
                 res->set_operation(M2MBase::GET_PUT_POST_ALLOWED);
                 // If resource is created then set the value.
-                char *buffer = (char*)malloc(BUFFER_SIZE);
+                uint32_t size = 0;
+                uint8_t* buffer = String::convert_integer_to_array(value, size);
+                res->set_value(buffer, size);
                 if(buffer) {
-                    uint32_t size = m2m::itoa_c(value, buffer);
-                    if (size <= BUFFER_SIZE) {
-                        res->set_value((const uint8_t*)buffer, size);
-                    }
                     free(buffer);
                 }
             }
@@ -189,11 +187,10 @@ bool M2MServer::set_resource_value(ServerResource resource,
            M2MServer::NotificationStorage == resource) {
             // If it is any of the above resource
             // set the value of the resource.
-            char *buffer = (char*)malloc(BUFFER_SIZE);
+            uint32_t size = 0;
+            uint8_t* buffer = String::convert_integer_to_array(value, size);
+            success = res->set_value(buffer, size);
             if(buffer) {
-                uint32_t size = m2m::itoa_c(value, buffer);
-                if (size <= BUFFER_SIZE)
-                    success = res->set_value((const uint8_t*)buffer, size);
                 free(buffer);
             }
         }
@@ -245,7 +242,7 @@ uint32_t M2MServer::resource_value_int(ServerResource resource) const
             uint32_t length = 0;
             res->get_value(buffer,length);
             if(buffer) {
-                value = atoi((const char*)buffer);
+                value = String::convert_array_to_integer(buffer,length);
                 free(buffer);
             }
         }

--- a/source/m2mstring.cpp
+++ b/source/m2mstring.cpp
@@ -398,4 +398,160 @@ namespace m2m {
       m2m::reverse(s, i);
       return i;
   }
+  uint8_t* String::convert_integer_to_array(int64_t value, uint32_t &size)
+  {
+      uint8_t* buffer;
+      if(value < 255) { // 0xFF
+          buffer = (uint8_t*)malloc(1);
+          *buffer = value;
+          size = 1;
+      } else if(value < 0xFFFF) { // 0xFFFF
+          buffer = (uint8_t*)malloc(2);
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          size = 2;
+      } else if(value < 0xFFFFFF) { // 0xFFFFFF 16777215
+          buffer = (uint8_t*)malloc(3);
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          size = 3;
+      } else if(value < 0xFFFFFFFF) { // 4294967295
+          buffer = (uint8_t*)malloc(4);
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 4;
+
+      } else if(value < 0xFFFFFFFFFF) { // 1099511627775
+          buffer = (uint8_t*)malloc(5);
+          *buffer++ = value >> 32;
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 5;
+
+      } else if(value < 0xFFFFFFFFFFFF) { // 281474976710655
+          buffer = (uint8_t*)malloc(6);
+          *buffer++ = value >> 40;
+          *buffer++ = value >> 32;
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 6;
+
+      } else if(value < 0xFFFFFFFFFFFFFF) { // 72057594037927935
+          buffer = (uint8_t*)malloc(7);
+          *buffer++ = value >> 48;
+          *buffer++ = value >> 40;
+          *buffer++ = value >> 32;
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 7;
+
+      } else {
+          buffer = (uint8_t*)malloc(8);
+          *buffer++ = value >> 56;
+          *buffer++ = value >> 48;
+          *buffer++ = value >> 40;
+          *buffer++ = value >> 32;
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 8;
+      }
+      return buffer;
+   }
+
+int64_t String::convert_array_to_integer(uint8_t *value, uint32_t size)
+{
+    int64_t temp_64 = 0;
+    if(size == 1) {
+        temp_64 += *value++;
+
+    } else if(size == 2) {
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+
+    } else if(size == 3) {
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+
+    } else if(size == 4) {
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+
+    } else if(size == 5) {
+        temp_64 += (uint64_t)(*value++) << 32;
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+
+    } else if(size == 6) {
+        temp_64 += (uint64_t)(*value++) << 40;
+        temp_64 += (uint64_t)(*value++) << 32;
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+    } else if(size == 7) {
+        temp_64 += (uint64_t)(*value++) << 48;
+        temp_64 += (uint64_t)(*value++) << 40;
+        temp_64 += (uint64_t)(*value++) << 32;
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+    } else if(size == 8) {
+        temp_64 = (uint64_t)(*value++) << 56;
+        temp_64 += (uint64_t)(*value++) << 48;
+        temp_64 += (uint64_t)(*value++) << 40;
+        temp_64 += (uint64_t)(*value++) << 32;
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+    }
+
+    return temp_64;
+}
+
 } // namespace

--- a/test/mbedclient/utest/m2mbase/m2mbasetest.cpp
+++ b/test/mbedclient/utest/m2mbase/m2mbasetest.cpp
@@ -227,3 +227,12 @@ TEST(M2MBase, test_id_number)
     m2m_base->test_id_number();
 }
 
+TEST(M2MBase, test_set_register_uri)
+{
+    m2m_base->test_set_register_uri();
+}
+
+TEST(M2MBase, test_register_uri)
+{
+    m2m_base->test_register_uri();
+}

--- a/test/mbedclient/utest/m2mbase/test_m2mbase.cpp
+++ b/test/mbedclient/utest/m2mbase/test_m2mbase.cpp
@@ -496,3 +496,15 @@ void Test_M2MBase::test_id_number()
     delete test1;
 
 }
+
+void Test_M2MBase::test_set_register_uri()
+{
+    this->set_register_uri(false);
+    CHECK(this->_register_uri == false);
+}
+
+void Test_M2MBase::test_register_uri()
+{
+    this->_register_uri = false;
+    CHECK(this->register_uri() == false);
+}

--- a/test/mbedclient/utest/m2mbase/test_m2mbase.h
+++ b/test/mbedclient/utest/m2mbase/test_m2mbase.h
@@ -100,6 +100,10 @@ public:
     void test_observation_handler();
 
     void test_id_number();
+
+    void test_set_register_uri();
+
+    void test_register_uri();
 };
 
 

--- a/test/mbedclient/utest/m2mdevice/test_m2mdevice.cpp
+++ b/test/mbedclient/utest/m2mdevice/test_m2mdevice.cpp
@@ -371,11 +371,11 @@ void Test_M2MDevice::test_set_resource_value_int()
 
 void Test_M2MDevice::test_resource_value_int()
 {
-    uint8_t value[] = {"10"};
+    uint8_t value = 10;
     uint8_t* ptr = (uint8_t*)malloc((uint32_t)sizeof(value));
     m2mresourceinstance_stub::value = ptr;
     memset(m2mresourceinstance_stub::value,0,(uint32_t)sizeof(value));
-    memcpy(m2mresourceinstance_stub::value,value,sizeof(value));
+    *m2mresourceinstance_stub::value = value;
     m2mresourceinstance_stub::int_value = (uint32_t)sizeof(value);
 
     m2mobjectinstance_stub::resource = new M2MResource(*m2mobject_stub::inst,"name","type",M2MResourceInstance::INTEGER,M2MBase::Dynamic);

--- a/test/mbedclient/utest/m2mfirmware/test_m2mfirmware.cpp
+++ b/test/mbedclient/utest/m2mfirmware/test_m2mfirmware.cpp
@@ -224,11 +224,11 @@ void Test_M2MFirmware::test_set_resource_value_int()
 
 void Test_M2MFirmware::test_resource_value_int()
 {
-    uint8_t value[] = {"10"};
+    uint8_t value = 10;
     uint8_t* ptr = (uint8_t*)malloc((uint32_t)sizeof(value));
     m2mresourceinstance_stub::value = ptr;
     memset(m2mresourceinstance_stub::value,0,(uint32_t)sizeof(value));
-    memcpy(m2mresourceinstance_stub::value,value,sizeof(value));
+    *m2mresourceinstance_stub::value = value;
     m2mresourceinstance_stub::int_value = (uint32_t)sizeof(value);
 
     m2mobjectinstance_stub::resource = new M2MResource(*m2mobject_stub::inst,

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
@@ -516,6 +516,13 @@ void Test_M2MNsdlInterface::test_received_from_server_callback()
 
     m2mobjectinstance_stub::header = NULL;
 
+    m2mobjectinstance_stub::header =  (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(m2mobjectinstance_stub::header, 0, sizeof(sn_coap_hdr_s));
+
+    m2mobjectinstance_stub::header->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
+    CHECK(0== nsdl->received_from_server_callback(NULL,coap_header,NULL));
+
+
     free(coap_header->payload_ptr);
     coap_header->payload_ptr = NULL;
 

--- a/test/mbedclient/utest/m2msecurity/test_m2msecurity.cpp
+++ b/test/mbedclient/utest/m2msecurity/test_m2msecurity.cpp
@@ -184,10 +184,10 @@ void Test_M2MSecurity::test_resource_value_int()
 {
     m2mresourceinstance_stub::bool_value = true;
 
-    uint8_t value[] = {"10"};
+    uint8_t value = 10;
     m2mresourceinstance_stub::value = (uint8_t*)malloc((uint32_t)sizeof(value));
     memset(m2mresourceinstance_stub::value,0,(uint32_t)sizeof(value));
-    memcpy(m2mresourceinstance_stub::value,value,sizeof(value));
+    *m2mresourceinstance_stub::value = value;
     m2mresourceinstance_stub::int_value = (uint16_t)sizeof(value);
 
     m2mobjectinstance_stub::resource = new M2MResource(*m2mobject_stub::inst,"name","type",M2MResourceInstance::STRING,M2MBase::Dynamic);

--- a/test/mbedclient/utest/m2mserver/test_m2mserver.cpp
+++ b/test/mbedclient/utest/m2mserver/test_m2mserver.cpp
@@ -160,10 +160,10 @@ void Test_M2MServer::test_set_resource_value_string()
 
 void Test_M2MServer::test_resource_value_int()
 {
-    uint8_t value[] = {"10"};
+    uint8_t value = 10;
     m2mresourceinstance_stub::value = (uint8_t*)malloc((uint32_t)sizeof(value));
     memset(m2mresourceinstance_stub::value,0,(uint32_t)sizeof(value));
-    memcpy(m2mresourceinstance_stub::value,value,sizeof(value));
+    *m2mresourceinstance_stub::value = value;
     m2mresourceinstance_stub::int_value = (uint32_t)sizeof(value);
 
     m2mobjectinstance_stub::resource = new M2MResource(*m2mobject_stub::inst,"name", "name", M2MResourceInstance::STRING, M2MBase::Dynamic);

--- a/test/mbedclient/utest/stub/common_stub.cpp
+++ b/test/mbedclient/utest/stub/common_stub.cpp
@@ -150,6 +150,11 @@ int8_t sn_nsdl_exec(struct nsdl_s *, uint32_t)
     return common_stub::int_value;
 }
 
+int8_t sn_nsdl_set_retransmission_parameters(struct nsdl_s *, uint8_t, uint8_t)
+{
+    return common_stub::int_value;
+}
+
 void sn_nsdl_release_allocated_coap_msg_mem(struct nsdl_s *, sn_coap_hdr_s *header)
 {
     if(header && header != common_stub::coap_header){

--- a/test/mbedclient/utest/stub/m2mbase_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mbase_stub.cpp
@@ -247,3 +247,12 @@ sn_coap_hdr_s* M2MBase::handle_post_request(nsdl_s */*nsdl*/,
     //Handled in M2MResource, M2MObjectInstance and M2MObject classes
     return NULL;
 }
+
+void M2MBase::set_register_uri( bool register_uri)
+{
+}
+
+bool M2MBase::register_uri()
+{
+    return m2mbase_stub::bool_value;
+}

--- a/test/mbedclient/utest/stub/m2mstring_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mstring_stub.cpp
@@ -362,6 +362,161 @@ namespace m2m {
   bool operator<( const String& s1, const String& s2 ) {
     return strcmp( s1.c_str(), s2.c_str() ) < 0;
   }
+  uint8_t* String::convert_integer_to_array(int64_t value, uint32_t &size)
+  {
+      uint8_t* buffer;
+      if(value < 255) { // 0xFF
+          buffer = (uint8_t*)malloc(1);
+          *buffer = value;
+          size = 1;
+      } else if(value < 0xFFFF) { // 0xFFFF
+          buffer = (uint8_t*)malloc(2);
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          size = 2;
+      } else if(value < 0xFFFFFF) { // 0xFFFFFF 16777215
+          buffer = (uint8_t*)malloc(3);
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          size = 3;
+      } else if(value < 0xFFFFFFFF) { // 4294967295
+          buffer = (uint8_t*)malloc(4);
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 4;
+
+      } else if(value < 0xFFFFFFFFFF) { // 1099511627775
+          buffer = (uint8_t*)malloc(5);
+          *buffer++ = value >> 32;
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 5;
+
+      } else if(value < 0xFFFFFFFFFFFF) { // 281474976710655
+          buffer = (uint8_t*)malloc(6);
+          *buffer++ = value >> 40;
+          *buffer++ = value >> 32;
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 6;
+
+      } else if(value < 0xFFFFFFFFFFFFFF) { // 72057594037927935
+          buffer = (uint8_t*)malloc(7);
+          *buffer++ = value >> 48;
+          *buffer++ = value >> 40;
+          *buffer++ = value >> 32;
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 7;
+
+      } else {
+          buffer = (uint8_t*)malloc(8);
+          *buffer++ = value >> 56;
+          *buffer++ = value >> 48;
+          *buffer++ = value >> 40;
+          *buffer++ = value >> 32;
+          *buffer++ = value >> 24;
+          *buffer++ = value >> 16;
+          *buffer++ = value >> 8;
+          *buffer = value;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          buffer--;
+          size = 8;
+      }
+      return buffer;
+   }
+
+int64_t String::convert_array_to_integer(uint8_t *value, uint32_t size)
+{
+    int64_t temp_64 = 0;
+    if(size == 1) {
+        temp_64 += *value++;
+
+    } else if(size == 2) {
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+
+    } else if(size == 3) {
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+
+    } else if(size == 4) {
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+
+    } else if(size == 5) {
+        temp_64 += (uint64_t)(*value++) << 32;
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+
+    } else if(size == 6) {
+        temp_64 += (uint64_t)(*value++) << 40;
+        temp_64 += (uint64_t)(*value++) << 32;
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+    } else if(size == 7) {
+        temp_64 += (uint64_t)(*value++) << 48;
+        temp_64 += (uint64_t)(*value++) << 40;
+        temp_64 += (uint64_t)(*value++) << 32;
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+    } else if(size == 8) {
+        temp_64 = (uint64_t)(*value++) << 56;
+        temp_64 += (uint64_t)(*value++) << 48;
+        temp_64 += (uint64_t)(*value++) << 40;
+        temp_64 += (uint64_t)(*value++) << 32;
+        temp_64 += (uint64_t)(*value++) << 24;
+        temp_64 += (uint64_t)(*value++) << 16;
+        temp_64 += (uint64_t)(*value++) << 8;
+        temp_64 += *value++;
+    }
+
+    return temp_64;
+}
 
   void reverse(char s[], uint32_t length)
   {


### PR DESCRIPTION
There is now feature that registered resources can be omitted from
registration message body that is sent to the server from client.
Also, fixed is the handling of integer values in OMA objects