### PR TITLE
Allow POST request on Resource with empty payload.

### DIFF
--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -429,13 +429,13 @@ uint8_t M2MNsdlInterface::received_from_server_callback(struct nsdl_s * /*nsdl_h
             }
         } else if(coap_header->msg_id == _unregister_id) {
             _unregister_id = 0;
+            tr_debug("M2MNsdlInterface::received_from_server_callback - unregistration callback");
             if(coap_header->msg_code == COAP_MSG_CODE_RESPONSE_DELETED) {
                 _registration_timer->stop_timer();
                 if(_server) {
                    delete _server;
                    _server = NULL;
                 }
-                tr_debug("M2MNsdlInterface::received_from_server_callback - unregistration callback");
                 _observer.client_unregistered();
             } else {
                 tr_error("M2MNsdlInterface::received_from_server_callback - unregistration error %d", coap_header->msg_code);
@@ -1066,7 +1066,6 @@ bool M2MNsdlInterface::create_nsdl_resource(M2MBase *base, const String &name, b
                     _resource->pathlen = name.length();
                 }
             }
-
             if(!base->resource_type().empty() && _resource->resource_parameters_ptr) {
                 _resource->resource_parameters_ptr->resource_type_ptr =
                        ((uint8_t*)memory_alloc(base->resource_type().length()+1));
@@ -1485,6 +1484,9 @@ void M2MNsdlInterface::send_resource_observation(M2MResource *resource,
 
         resource->get_observation_token(token,token_length);
         uint8_t content_type = 0;
+        if(M2MResourceInstance::OPAQUE == resource->resource_instance_type()) {
+            content_type = COAP_CONTENT_OMA_OPAQUE_TYPE;
+        }
         if (resource->resource_instance_count() > 0) {
             M2MTLVSerializer *serializer = new M2MTLVSerializer();
             content_type = COAP_CONTENT_OMA_TLV_TYPE;

--- a/source/m2mobjectinstance.cpp
+++ b/source/m2mobjectinstance.cpp
@@ -57,7 +57,7 @@ M2MObjectInstance::M2MObjectInstance(const String &object_name,
   _object_callback(object_callback)
 {
     M2MBase::set_base_type(M2MBase::ObjectInstance);
-
+    M2MBase::set_coap_content_type(COAP_CONTENT_OMA_TLV_TYPE);
 }
 
 M2MObjectInstance::~M2MObjectInstance()

--- a/source/m2mresource.cpp
+++ b/source/m2mresource.cpp
@@ -553,8 +553,14 @@ sn_coap_hdr_s* M2MResource::handle_post_request(nsdl_s *nsdl,
     if(received_coap_header) {
         if ((operation() & SN_GRS_POST_ALLOWED) != 0) {
             M2MResource::M2MExecuteParameter *exec_params = NULL;
+            uint16_t coap_content_type = 0;
             if(received_coap_header->payload_ptr) {
-                if(received_coap_header->content_type_ptr && *received_coap_header->content_type_ptr == 0) {
+                if(received_coap_header->content_type_ptr) {
+                    for(uint8_t i = 0; i < received_coap_header->content_type_len; i++) {
+                        coap_content_type = (coap_content_type << 8) + (received_coap_header->content_type_ptr[i] & 0xFF);
+                    }
+                }
+                if(coap_content_type == 0) {
                     exec_params = new M2MResource::M2MExecuteParameter();
                     if (exec_params){
                         exec_params->_value = (uint8_t*)malloc(received_coap_header->payload_len+1);

--- a/source/m2mresource.cpp
+++ b/source/m2mresource.cpp
@@ -551,24 +551,26 @@ sn_coap_hdr_s* M2MResource::handle_post_request(nsdl_s *nsdl,
                                                            msg_code);
     // process the POST if we have registered a callback for it
     if(received_coap_header) {
-        if ((operation() & SN_GRS_POST_ALLOWED) != 0) {            
-            if(received_coap_header->content_type_ptr && *received_coap_header->content_type_ptr != 0) {
-                msg_code = COAP_MSG_CODE_RESPONSE_UNSUPPORTED_CONTENT_FORMAT;
-            } else {
-                M2MResource::M2MExecuteParameter *exec_params = NULL;
-                if(received_coap_header->payload_ptr) {
+        if ((operation() & SN_GRS_POST_ALLOWED) != 0) {
+            M2MResource::M2MExecuteParameter *exec_params = NULL;
+            if(received_coap_header->payload_ptr) {
+                if(received_coap_header->content_type_ptr && *received_coap_header->content_type_ptr == 0) {
                     exec_params = new M2MResource::M2MExecuteParameter();
                     if (exec_params){
-                        exec_params->_value = (uint8_t*)malloc(received_coap_header->payload_len);
+                        exec_params->_value = (uint8_t*)malloc(received_coap_header->payload_len+1);
                         if (exec_params->_value) {
-                            memset(exec_params->_value, 0, received_coap_header->payload_len);
+                            memset(exec_params->_value, 0, received_coap_header->payload_len+1);
                             memcpy(exec_params->_value,
                                 received_coap_header->payload_ptr,
                                 received_coap_header->payload_len);
                             exec_params->_value_length = received_coap_header->payload_len;
                         }
                     }
+                } else {
+                    msg_code = COAP_MSG_CODE_RESPONSE_UNSUPPORTED_CONTENT_FORMAT;
                 }
+            }
+            if(COAP_MSG_CODE_RESPONSE_CHANGED == msg_code) {
                 tr_debug("M2MResource::handle_post_request - Execute resource function");
                 execute(exec_params);
                 delete exec_params;

--- a/source/m2mresource.cpp
+++ b/source/m2mresource.cpp
@@ -579,7 +579,9 @@ sn_coap_hdr_s* M2MResource::handle_post_request(nsdl_s *nsdl,
             if(COAP_MSG_CODE_RESPONSE_CHANGED == msg_code) {
                 tr_debug("M2MResource::handle_post_request - Execute resource function");
                 execute(exec_params);
-                delete exec_params;
+                if(exec_params) {
+                    delete exec_params;
+                }
 
                 if(_delayed_response) {
                     coap_response->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
@@ -1301,6 +1301,11 @@ void Test_M2MNsdlInterface::test_observation_to_be_sent()
     //CHECK if nothing crashes
     nsdl->observation_to_be_sent(res2, 1, instance_list_ids);
 
+    m2mresourceinstance_stub::resource_type = M2MResource::OPAQUE;
+
+    //CHECK if nothing crashes
+    nsdl->observation_to_be_sent(res2, 1, instance_list_ids);
+
     m2mresource_stub::list.clear();
     m2mresource_stub::int_value = 0;
 


### PR DESCRIPTION
This commit handles the case where there is POST request on Resource with
empty payload , there is no check for content-type and it will allow to
execute the resource without any payload.
Also, fixed is the case where right content type is set for OPAQUE resource when sending notifications.