### PR TITLE
Removing code tags from the table

### DIFF
--- a/docs/release-note-mbed-client-1511.md
+++ b/docs/release-note-mbed-client-1511.md
@@ -42,15 +42,15 @@ This release comprises the following yotta modules and their versions:
 
 | Module                           |  Version   |
 |----------------------------------|------------|
-| `mbed-client`                    |   1.2.1	   |
-| `mbed-client-c`                  |   1.1.1	   |
-| `mbed-client-libservice`         |   3.0.8	   |
-| `mbed-client-linux`              |   1.1.0	   |
-| `mbed-client-linux-example`  	   |   1.0.0	   |
-| `mbedtls`  	 		                  |   2.2.0	   |
-| `mbed-client-mbed-tls`           |   1.0.9	   |
-| `target-x86-linux-native`        |   1.0.0	   |
-| `target-linux-native`            |   1.0.0	   |
+| mbed-client                    |   1.2.1	   |
+| mbed-client-c                  |   1.1.1	   |
+| mbed-client-libservice         |   3.0.8	   |
+| mbed-client-linux              |   1.1.0	   |
+| mbed-client-linux-example  	   |   1.0.0	   |
+| mbedtls  	 		                  |   2.2.0	   |
+| mbed-client-mbed-tls           |   1.0.9	   |
+| target-x86-linux-native        |   1.0.0	   |
+| target-linux-native            |   1.0.0	   |
 
 
 


### PR DESCRIPTION
Tables with code tags don't render on docs.mbed at the moment; easiest to remove them so that the table renders correctly. In the context of the table the distinction between the two fonts isn't very helpful anyway