### PR TITLE
Remove direct references to Linux platform implementations

### DIFF
--- a/sources.mk
+++ b/sources.mk
@@ -18,15 +18,7 @@ SRCS += \
 	source/m2mtlvserializer.cpp \
 	source/nsdlaccesshelper.cpp \
 	source/m2mfirmware.cpp \
-	../lwm2m-client-linux/source/m2mconnectionhandler.cpp \
-	../lwm2m-client-linux/source/m2mconnectionhandlerpimpl.cpp \
-	../lwm2m-client-linux/source/m2mtimer.cpp \
-	../lwm2m-client-linux/source/m2mtimerpimpl.cpp \
-	../lwm2m-client-linux/source/connthreadhelper.cpp \
-	../lwm2m-client-linux/source/threadhelper.cpp \
-        ../lwm2m-client-mbedtls/source/m2mconnectionsecurity.cpp \
-        ../lwm2m-client-mbedtls/source/m2mconnectionsecuritypimpl.cpp \
-	
+
 
 
 


### PR DESCRIPTION
In order to port this component to nanostack, the makefile can
not compile the linux specific parts into the libmbedclient.a.