### PR TITLE
Fixes issue in push_back when capacity is full

### DIFF
--- a/mbed-client/m2mvector.h
+++ b/mbed-client/m2mvector.h
@@ -100,7 +100,7 @@ class Vector
     }
 
     void push_back(const ObjectTemplate& x) {
-        if(_size == _capacity) {
+        if(_size == _capacity -1) {
             reserve(2 * _capacity + 1);
         }
         _object_template[_index++] = x;


### PR DESCRIPTION
Previous implementation overwrote the last item in the list when
the list was expanded (due the _index--). This now resizes the list
one step in advance, so this issue is avoided.