### PR TITLE
Extending API to support TLS functionality

### DIFF
--- a/mbed-client/m2mconfig.h
+++ b/mbed-client/m2mconfig.h
@@ -22,4 +22,33 @@
 #include "mbed-client/m2mstring.h"
 using namespace m2m;
 
+// This is valid for mbed-client-mbedtls
+// For other SSL implementation there
+// can be other
+
+/*
+*\brief Callback function for Random number
+* required by mbed-client-mbedtls module
+*/
+typedef uint32_t (*random_number_cb)(void) ;
+
+/*
+*\brief Entropy structure for mbedtls entropy source
+* \param entropy_source_ptr  Entropy function
+* \param p_source  Function data
+* \param threshold Minimum required from source before entropy is released
+*                  ( with mbedtls_entropy_func() ) (in bytes)
+* \param strong    MBEDTLS_ENTROPY_SOURCE_STRONG = 1 or
+*                  MBEDTSL_ENTROPY_SOURCE_WEAK = 0.
+*                  At least one strong source needs to be added.
+*                  Weaker sources (such as the cycle counter) can be used as
+*                  a complement.
+*/
+typedef struct mbedtls_entropy {
+int     (*entropy_source_ptr)(void *, unsigned char *,size_t , size_t *);
+void    *p_source;
+size_t  threshold;
+int     strong;
+}entropy_cb;
+
 #endif // M2MCONFIG_H

--- a/mbed-client/m2mconnectionsecurity.h
+++ b/mbed-client/m2mconnectionsecurity.h
@@ -16,6 +16,7 @@
 #ifndef __M2M_CONNECTION_SECURITY_H__
 #define __M2M_CONNECTION_SECURITY_H__
 
+#include "mbed-client/m2mconfig.h"
 class M2MConnectionHandler;
 class M2MSecurity;
 class M2MConnectionSecurityPimpl;
@@ -98,6 +99,26 @@ public:
      * \return Indicates whether the data is read successfully or not.
      */
     int read(unsigned char* buffer, uint16_t len);
+
+    /**
+     * \brief Sets the function callback that will be called by mbed-client for
+     * fetching random number from application for ensuring strong entropy.
+     * \param random_callback A function pointer that will be called by mbed-client
+     * while performing secure handshake.
+     * Function signature should be uint32_t (*random_number_callback)(void);
+     */
+    void set_random_number_callback(random_number_cb callback);
+
+    /**
+     * \brief Sets the function callback that will be called by mbed-client for
+     * providing entropy source from application for ensuring strong entropy.
+     * \param entropy_callback A function pointer that will be called by mbed-client
+     * while performing secure handshake.
+     * Function signature , if using mbed-client-mbedtls should be
+     * int (*mbedtls_entropy_f_source_ptr)(void *data, unsigned char *output,
+     *                                     size_t len, size_t *olen);
+     */
+    void set_entropy_callback(entropy_cb callback);
 
 private:
 

--- a/mbed-client/m2minterface.h
+++ b/mbed-client/m2minterface.h
@@ -150,6 +150,25 @@ public:
      */
     virtual void set_queue_sleep_handler(callback_handler handler) = 0;
 
+    /**
+     * \brief Sets the function callback that will be called by mbed-client for
+     * fetching random number from application for ensuring strong entropy.
+     * \param random_callback A function pointer that will be called by mbed-client
+     * while performing secure handshake.
+     * Function signature should be uint32_t (*random_number_callback)(void);
+     */
+    virtual void set_random_number_callback(random_number_cb callback) = 0;
+
+    /**
+     * \brief Sets the function callback that will be called by mbed-client for
+     * providing entropy source from application for ensuring strong entropy.
+     * \param entropy_callback A function pointer that will be called by mbed-client
+     * while performing secure handshake.
+     * Function signature , if using mbed-client-mbedtls should be
+     * int (*mbedtls_entropy_f_source_ptr)(void *data, unsigned char *output,
+     *                                     size_t len, size_t *olen);
+     */
+    virtual void set_entropy_callback(entropy_cb callback) = 0;
 };
 
 #endif // M2M_INTERFACE_H

--- a/module.json
+++ b/module.json
@@ -13,11 +13,11 @@
   "targetDependencies": {
     "arm": {
       "mbed-client-mbed-os": "^1.0.0",
-      "mbed-client-mbedtls": "^1.0.0"
+      "mbed-client-mbedtls": "^2.0.0"
     },
     "linux": {
       "mbed-client-linux": "^1.0.0",
-      "mbed-client-mbedtls": "^1.0.0"
+      "mbed-client-mbedtls": "^2.0.0"
     }
   }
 }

--- a/source/include/m2minterfaceimpl.h
+++ b/source/include/m2minterfaceimpl.h
@@ -25,6 +25,7 @@
 //FORWARD DECLARATION
 class M2MNsdlInterface;
 class M2MConnectionHandler;
+class M2MConnectionSecurity;
 class EventData;
 class M2MTimer;
 
@@ -134,6 +135,27 @@ public:
      * goes to seleep.
      */
     virtual void set_queue_sleep_handler(callback_handler handler);
+
+    /**
+     * \brief Sets the function callback that will be called by mbed-client for
+     * fetching random number from application for ensuring strong entropy.
+     * \param random_callback A function pointer that will be called by mbed-client
+     * while performing secure handshake.
+     * Function signature should be uint32_t (*random_number_callback)(void);
+     */
+    virtual void set_random_number_callback(random_number_cb callback);
+
+    /**
+     * \brief Sets the function callback that will be called by mbed-client for
+     * providing entropy source from application for ensuring strong entropy.
+     * \param entropy_callback A function pointer that will be called by mbed-client
+     * while performing secure handshake.
+     * Function signature , if using mbed-client-mbedtls should be
+     * int (*mbedtls_entropy_f_source_ptr)(void *data, unsigned char *output,
+     *                                     size_t len, size_t *olen);
+     */
+    virtual void set_entropy_callback(entropy_cb callback);
+
 
 protected: // From M2MNsdlObserver
 
@@ -344,6 +366,7 @@ private:
 
     M2MInterfaceObserver        &_observer;
     M2MConnectionHandler        *_connection_handler;
+    M2MConnectionSecurity       *_security_connection; // Doesn't own
     M2MNsdlInterface            *_nsdl_interface;
     uint8_t                     _current_state;
     const int                   _max_states;

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -73,8 +73,10 @@ M2MInterfaceImpl::M2MInterfaceImpl(M2MInterfaceObserver& observer,
                                      (uint8_t)_binding_mode,
                                      _context_address);
 
+    //Doesn't own, ownership is passed to ConnectionHandler class
+    _security_connection = new M2MConnectionSecurity(sec_mode);
     //Here we must use TCP still
-    _connection_handler = new M2MConnectionHandler(*this, new M2MConnectionSecurity(sec_mode), mode, stack);
+    _connection_handler = new M2MConnectionHandler(*this, _security_connection, mode, stack);
 
     _connection_handler->bind_connection(_listen_port);
     tr_debug("M2MInterfaceImpl::M2MInterfaceImpl() -OUT");
@@ -88,6 +90,7 @@ M2MInterfaceImpl::~M2MInterfaceImpl()
     delete _nsdl_interface;
     _connection_handler->stop_listening();
     delete _connection_handler;
+    _security_connection = NULL;
     tr_debug("M2MInterfaceImpl::~M2MInterfaceImpl() - OUT");
 }
 
@@ -257,6 +260,20 @@ void M2MInterfaceImpl::set_queue_sleep_handler(callback_handler handler)
 {
     tr_debug("M2MInterfaceImpl::set_queue_sleep_handler()");
     _callback_handler = handler;
+}
+
+void M2MInterfaceImpl::set_random_number_callback(random_number_cb callback)
+{
+    if(_security_connection) {
+        _security_connection->set_random_number_callback(callback);
+    }
+}
+
+void M2MInterfaceImpl::set_entropy_callback(entropy_cb callback)
+{
+    if(_security_connection) {
+        _security_connection->set_entropy_callback(callback);
+    }
 }
 
 void M2MInterfaceImpl::coap_message_ready(uint8_t *data_ptr,

--- a/test/mbedclient/utest/m2minterfaceimpl/m2minterfaceimpltest.cpp
+++ b/test/mbedclient/utest/m2minterfaceimpl/m2minterfaceimpltest.cpp
@@ -72,6 +72,16 @@ TEST(M2MInterfaceImpl, set_queue_sleep_handler)
     m2m_interface_impl->test_set_queue_sleep_handler();
 }
 
+TEST(M2MInterfaceImpl, test_set_random_number_callback)
+{
+    m2m_interface_impl->test_set_random_number_callback();
+}
+
+TEST(M2MInterfaceImpl, test_set_entropy_callback)
+{
+    m2m_interface_impl->test_set_entropy_callback();
+}
+
 TEST(M2MInterfaceImpl, coap_message_ready)
 {
     m2m_interface_impl->test_coap_message_ready();

--- a/test/mbedclient/utest/m2minterfaceimpl/test_m2minterfaceimpl.cpp
+++ b/test/mbedclient/utest/m2minterfaceimpl/test_m2minterfaceimpl.cpp
@@ -23,6 +23,8 @@
 #include "m2mobjectinstance_stub.h"
 #include "m2mbase.h"
 
+entropy_cb ent_cb;
+
 class TestObserver : public M2MInterfaceObserver {
 
 public:
@@ -430,6 +432,18 @@ void Test_M2MInterfaceImpl::test_set_queue_sleep_handler()
     CHECK(impl->_callback_handler == NULL);
 }
 
+
+void Test_M2MInterfaceImpl::test_set_random_number_callback()
+{
+    random_number_cb cb(&test_random_callback);
+    impl->set_random_number_callback(cb);
+}
+
+void Test_M2MInterfaceImpl::test_set_entropy_callback()
+{
+    impl->set_entropy_callback(ent_cb);
+}
+
 void Test_M2MInterfaceImpl::test_coap_message_ready()
 {
     m2mconnectionhandler_stub::bool_value = true;
@@ -692,4 +706,9 @@ void Test_M2MInterfaceImpl::test_timer_expired()
 void Test_M2MInterfaceImpl::test_callback_handler()
 {
     visited = true;
+}
+
+uint32_t test_random_callback(void)
+{
+    return 1;
 }

--- a/test/mbedclient/utest/m2minterfaceimpl/test_m2minterfaceimpl.h
+++ b/test/mbedclient/utest/m2minterfaceimpl/test_m2minterfaceimpl.h
@@ -20,6 +20,8 @@
 
 class TestObserver;
 
+uint32_t test_random_callback(void);
+
 class Test_M2MInterfaceImpl
 {
 public:
@@ -40,6 +42,10 @@ public:
     void test_unregister_object();
 
     void test_set_queue_sleep_handler();
+
+    void test_set_random_number_callback();
+
+    void test_set_entropy_callback();
 
     void test_coap_message_ready();
 

--- a/test/mbedclient/utest/stub/m2mconnectionsecurity_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mconnectionsecurity_stub.cpp
@@ -86,3 +86,13 @@ int M2MConnectionSecurity::read(unsigned char* buffer, uint16_t len){
     }
     return m2mconnectionsecurityimpl_stub::int_value;
 }
+
+void M2MConnectionSecurity::set_random_number_callback(random_number_cb)
+{
+
+}
+
+void M2MConnectionSecurity::set_entropy_callback(mbedtls_entropy)
+{
+
+}

--- a/test/mbedclient/utest/stub/m2minterfaceimpl_stub.cpp
+++ b/test/mbedclient/utest/stub/m2minterfaceimpl_stub.cpp
@@ -72,6 +72,16 @@ void M2MInterfaceImpl::set_queue_sleep_handler(callback_handler)
 
 }
 
+void M2MInterfaceImpl::set_random_number_callback(random_number_cb)
+{
+
+}
+
+void M2MInterfaceImpl::set_entropy_callback(entropy_cb)
+{
+
+}
+
 void M2MInterfaceImpl::coap_message_ready(uint8_t *,
                                 uint16_t ,
                                 sn_nsdl_addr_s *)


### PR DESCRIPTION
New APIs are introduces keeping backward compatibility
- set_random_number_callback()
  Application can pass their own platform specific random generation function callback
  which will be used be mbed-client-mbedtls to fetch random number, if not called, mbed-client-mbedtls
  continues to use default implementation which doesn't guarantee strong randomization.
- set_entropy_callback()
 Application can pass the entropy_cb function which contains strong callback function, Threshold and
 Entropy strength. mbed-client-mbedtls will add this as another source to entropy list apart from its
 default entropy source, which is NOT strong entropy source.