### PR TITLE
Fix a compilation error on armcc+trace combination

### DIFF
--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -13,6 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Note: this macro is needed on armcc to get the the PRI*32 macros
+// from inttypes.h in a C++ code.
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include "mbed-client/m2mstring.h"
 #include "include/nsdlaccesshelper.h"
 #include "include/m2mnsdlobserver.h"


### PR DESCRIPTION
The armcc build failed for the lack of PRId32/PRIu32
macros. It seems that it requires a separate define
to be used on C++ code before including the inttypes.h,
or the PRI-macros do not get defined.