### PR TITLE
Add support for IAR

### DIFF
--- a/mbed-client/m2mbase.h
+++ b/mbed-client/m2mbase.h
@@ -198,7 +198,7 @@ public:
      * \param observation_number Observation number of the object.
      */
     virtual void set_observation_number(const uint16_t observation_number)
-        __attribute__ ((deprecated));
+        m2m_deprecated;
 
     /**
      * \brief Sets the max age for the resource value to be cached.

--- a/mbed-client/m2mconfig.h
+++ b/mbed-client/m2mconfig.h
@@ -34,6 +34,12 @@ using namespace m2m;
 #define YOTTA_CFG_TCP_KEEPALIVE_TIME 300
 #endif
 
+#if defined (__ICCARM__)
+#define m2m_deprecated
+#else
+#define m2m_deprecated __attribute__ ((deprecated))
+#endif
+
 // This is valid for mbed-client-mbedtls
 // For other SSL implementation there
 // can be other


### PR DESCRIPTION
Create the attribute m2m_deprecated and define this for both IAR and
GCC.  Use this attribute rather than GCC specific syntax.  This allows
mbed-client to compile for IAR.