### PR TITLE
Remove inclusion of obsolete socket_security.h

### DIFF
--- a/test/lwm2mtestapplication/cmd_commands.cpp
+++ b/test/lwm2mtestapplication/cmd_commands.cpp
@@ -22,7 +22,6 @@
 #include "eventOS_event_timer.h"
 #include "net_interface.h"
 #include "socket_api.h"
-#include "socket_security.h"
 #include "mbed-trace/mbed_trace.h"
 #include "common_functions.h"
 

--- a/test/mbedclient/utest/stub/common_stub.cpp
+++ b/test/mbedclient/utest/stub/common_stub.cpp
@@ -243,11 +243,12 @@ int8_t sn_coap_protocol_set_retransmission_parameters(uint8_t, uint8_t)
 }
 
 // IP6String.h
-void ip6tos(const void *ip6addr, char *p)
+uint_fast8_t ip6tos(const void *ip6addr, char *p)
 {
     // Just set at least something there, or the valgrind will scream when
     // client tries to use the result string.
     p[0] = '\0';
+    return 0;
 }
 
 //Socket


### PR DESCRIPTION
Nanostack's `socket_security.h` is obsolete header.

Remove it, so next release can drop that from nanostack.
