### PR TITLE
m2mnsdlinterface.cpp: added mutex calls to protect sn_nsdl_process_coap and sn_nsdl_exec

### DIFF
--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -662,10 +662,12 @@ bool M2MNsdlInterface::process_received_data(uint8_t *data,
                                              sn_nsdl_addr_s *address)
 {
     tr_debug("M2MNsdlInterface::process_received_data( data size %d)", data_size);
+    __mutex_claim();
     return (0 == sn_nsdl_process_coap(_nsdl_handle,
                                       data,
                                       data_size,
                                       address)) ? true : false;
+    __mutex_release();
 }
 
 void M2MNsdlInterface::stop_timers()
@@ -686,7 +688,9 @@ void M2MNsdlInterface::stop_timers()
 void M2MNsdlInterface::timer_expired(M2MTimerObserver::Type type)
 {
     if(M2MTimerObserver::NsdlExecution == type) {
+        __mutex_claim();
         sn_nsdl_exec(_nsdl_handle, _counter_for_nsdl);
+        __mutex_release();
         _counter_for_nsdl++;
     } else if(M2MTimerObserver::Registration == type) {
         tr_debug("M2MNsdlInterface::timer_expired - M2MTimerObserver::Registration - Send update registration");


### PR DESCRIPTION
Added __mutex_claim before and __mutex_release after sn_nsdl_process_coap and sn_nsdl_exec as they access same resources.