### PR TITLE
Fix for IOTCLT-961

### DIFF
--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -603,6 +603,7 @@ void M2MInterfaceImpl::state_bootstrap_address_resolved( EventData *data)
     }
     address.port = event->_port;
     address.addr_ptr = (uint8_t*)event->_address->_address;
+    address.addr_len = event->_address->_length;
     _connection_handler->start_listening_for_data();
 
     // Include domain id to be part of endpoint name
@@ -819,6 +820,7 @@ void M2MInterfaceImpl::state_coap_data_received( EventData *data)
         }
         address.port = event->_address->_port;
         address.addr_ptr = (uint8_t*)event->_address->_address;
+        address.addr_len = event->_address->_length;
 
         // Process received data
         internal_event(STATE_PROCESSING_COAP_DATA);

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -636,9 +636,6 @@ void M2MInterfaceImpl::state_bootstrapped( EventData */*data*/)
 {
 #ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
     tr_debug("M2MInterfaceImpl::state_bootstrapped");
-    _connection_handler->stop_listening();
-    _listen_port = rand() % 64511 + 1024;
-    _connection_handler->bind_connection(_listen_port);
 #endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
 }
 


### PR DESCRIPTION
This commit fixes issue of mapping of IP addresses for CoAP library is done.
The problem was hidden till now, because IP addresses of Bootstrap and mDS were quite different and client was accidently only comparing first 4 characters of the address hence it was identifying them as two different servers.
But now the IP addresses are similar to last 2 bytes hence the first 4 byte check always pass even though the IP addresses are different
IP Address of Bootstrap is 159.122.226.36
IP Address of mDS is 159.122.226.33
On comparing the first 4 characters now, the CoAP library assumes the requests are still coming for Bootstrap sequence.
This commit fixes this issue.