### PR TITLE
implement platform agnostic IP handling, Fix IOTCLT-1001

### DIFF
--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -112,6 +112,7 @@ public:
      * @return  true if register sent successfully else false.
     */
     bool send_register_message(uint8_t* address,
+                               uint8_t address_length,
                                const uint16_t port,
                                sn_nsdl_addr_type_e address_type);
 

--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -107,6 +107,7 @@ public:
     /**
      * @brief Sends the register message to the server.
      * @param address M2MServer address.
+     * @param address_length M2MServer address length.
      * @param port M2MServer port.
      * @param address_type IP Address type.
      * @return  true if register sent successfully else false.

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -732,7 +732,8 @@ void M2MInterfaceImpl::state_register_address_resolved( EventData *data)
             address_type = SN_NSDL_ADDRESS_TYPE_IPV6;
         }
         _connection_handler->start_listening_for_data();
-        if(_nsdl_interface->send_register_message((uint8_t*)event->_address->_address,event->_port, address_type)) {
+        if(_nsdl_interface->send_register_message((uint8_t*)event->_address->_address,event->_address->_length,
+                                                  event->_port, address_type)) {
             internal_event(STATE_REGISTER_RESOURCE_CREATED);
         } else {
             // If resource creation fails then inform error to application

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -594,12 +594,10 @@ void M2MInterfaceImpl::state_bootstrap_address_resolved( EventData *data)
     if(M2MInterface::LwIP_IPv4 == stack) {
         tr_debug("M2MInterfaceImpl::state_bootstrap_address_resolved : IPv4 address");
         address.type = SN_NSDL_ADDRESS_TYPE_IPV4;
-        address.addr_len = 4;
     } else if((M2MInterface::LwIP_IPv6 == stack) ||
               (M2MInterface::Nanostack_IPv6 == stack)) {
         tr_debug("M2MInterfaceImpl::state_bootstrap_address_resolved : IPv6 address");
         address.type = SN_NSDL_ADDRESS_TYPE_IPV6;
-        address.addr_len = 16;
     }
     address.port = event->_port;
     address.addr_ptr = (uint8_t*)event->_address->_address;

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -269,6 +269,7 @@ bool M2MNsdlInterface::create_bootstrap_resource(sn_nsdl_addr_s *address, const 
 }
 
 bool M2MNsdlInterface::send_register_message(uint8_t* address,
+                                             uint8_t address_length,
                                              const uint16_t port,
                                              sn_nsdl_addr_type_e address_type)
 {
@@ -278,7 +279,7 @@ bool M2MNsdlInterface::send_register_message(uint8_t* address,
                                        M2MTimerObserver::NsdlExecution,
                                        false);
     bool success = false;
-    if(set_NSP_address(_nsdl_handle,address, port, address_type) == 0) {
+    if(set_NSP_address_2(_nsdl_handle, address, address_length, port, address_type) == 0) {
         if(!_register_ongoing) {
             _register_ongoing = true;
             success = sn_nsdl_register_endpoint(_nsdl_handle,_endpoint) != 0;

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
@@ -236,10 +236,10 @@ void Test_M2MNsdlInterface::test_create_bootstrap_resource()
 void Test_M2MNsdlInterface::test_send_register_message()
 {
     common_stub::uint_value = 12;
-    CHECK(nsdl->send_register_message(NULL,100,SN_NSDL_ADDRESS_TYPE_IPV6) == true);
+    CHECK(nsdl->send_register_message(NULL,4,100,SN_NSDL_ADDRESS_TYPE_IPV6) == true);
 
     common_stub::uint_value = 0;
-    CHECK(nsdl->send_register_message(NULL,100,SN_NSDL_ADDRESS_TYPE_IPV6) == false);
+    CHECK(nsdl->send_register_message(NULL,4,100,SN_NSDL_ADDRESS_TYPE_IPV6) == false);
 }
 
 void Test_M2MNsdlInterface::test_send_update_registration()

--- a/test/mbedclient/utest/stub/common_stub.cpp
+++ b/test/mbedclient/utest/stub/common_stub.cpp
@@ -199,7 +199,7 @@ int8_t sn_nsdl_update_resource(struct nsdl_s *, sn_nsdl_resource_info_s *)
     return common_stub::int_value;
 }
 
-int8_t set_NSP_address(struct nsdl_s *, uint8_t *, uint16_t, sn_nsdl_addr_type_e)
+int8_t set_NSP_address_2(struct nsdl_s *, uint8_t *, uint8_t, uint16_t, sn_nsdl_addr_type_e)
 {
     return common_stub::int_value;
 }

--- a/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
@@ -71,6 +71,7 @@ bool M2MNsdlInterface::create_bootstrap_resource(sn_nsdl_addr_s *, const String&
 }
 
 bool M2MNsdlInterface::send_register_message(uint8_t*,
+                                             uint8_t,
                                              const uint16_t,
                                              sn_nsdl_addr_type_e)
 {


### PR DESCRIPTION
This is fix for address handling in mbed Client (and mbed-client-c). There is an issue that the current implementation presumes that the IP is given as byte array, whereas some platforms give instead a char pointer. This should fix some CoAP messages being ignored by Client (due to not recognizing the IP).

@yogpan01 @anttiylitokola 