### PR TITLE
m2mstring: add new version of constructor that gets string and len

### DIFF
--- a/mbed-client/m2mstring.h
+++ b/mbed-client/m2mstring.h
@@ -42,6 +42,7 @@ namespace m2m
     ~String();
     String(const String&);
     String(const char*);
+    String(const char*, size_t);
 
     String& operator=(const char*);
     String& operator=(const String&);

--- a/source/m2mstring.cpp
+++ b/source/m2mstring.cpp
@@ -61,6 +61,16 @@ String::String(const char* s)
 {
 }
 
+String::String(const char* str, size_t n)
+{
+    p = static_cast<char*>(malloc(n + 1));
+
+    allocated_ = n + 1;
+    size_      = n;
+    memcpy(p, str, n);
+    p[n] = 0;
+}
+
 String& String::operator=(const char* s)
 {
     if ( p != s ) {

--- a/test/mbedclient/utest/m2mstring/m2mstringtest.cpp
+++ b/test/mbedclient/utest/m2mstring/m2mstringtest.cpp
@@ -36,6 +36,11 @@ TEST(M2MString, Create)
     CHECK(m2m_string != NULL);
 }
 
+TEST(M2MString, string_and_len_constructor)
+{
+    m2m_string->test_string_and_len_constructor();
+}
+
 TEST(M2MString, copy_constructor)
 {
     m2m_string->test_copy_constructor();

--- a/test/mbedclient/utest/m2mstring/test_m2mstring.cpp
+++ b/test/mbedclient/utest/m2mstring/test_m2mstring.cpp
@@ -28,11 +28,20 @@ Test_M2MString::~Test_M2MString()
     delete str;
 }
 
+void Test_M2MString::test_string_and_len_constructor()
+{
+    // make sure the len parameter works as expected
+    String s("hello_world", 5);
+    CHECK(s == "hello");
+    CHECK(s.size() == 5);
+}
+
 void Test_M2MString::test_copy_constructor()
 {
     String s("name");
     String s1(s);
     CHECK(s1.p[1] == 'a');
+    CHECK(s.size() == s1.size());
 }
 
 void Test_M2MString::test_operator_assign()

--- a/test/mbedclient/utest/m2mstring/test_m2mstring.h
+++ b/test/mbedclient/utest/m2mstring/test_m2mstring.h
@@ -26,6 +26,7 @@ public:
     Test_M2MString();
     virtual ~Test_M2MString();
 
+    void test_string_and_len_constructor();
     void test_copy_constructor();
     void test_operator_assign();
     void test_operator_add();

--- a/test/mbedclient/utest/stub/m2mstring_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mstring_stub.cpp
@@ -61,6 +61,16 @@ String::String(const char* s)
 {
 }
 
+String::String(const char* str, size_t n)
+{
+    p = static_cast<char*>(malloc(n + 1));
+
+    allocated_ = n + 1;
+    size_      = n;
+    memcpy(p, str, n);
+    p[n] = 0;
+}
+
 String& String::operator=(const char* s)
 {
     if ( p != s ) {


### PR DESCRIPTION
There is need for easily constructing a string out of block of
non zero terminated memory and length. Add new overload of constructor
and unit tests for it.