### PR TITLE
Fix most of gcc warnings from invalid trace format specifiers

### DIFF
--- a/source/m2minterfacefactory.cpp
+++ b/source/m2minterfacefactory.cpp
@@ -13,6 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Note: this macro is needed on armcc to get the the PRI*32 macros
+// from inttypes.h in a C++ code.
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include "mbed-client/m2minterfacefactory.h"
 #include "mbed-client/m2mserver.h"
 #include "mbed-client/m2mdevice.h"
@@ -22,6 +29,8 @@
 #include "mbed-client/m2mconfig.h"
 #include "include/m2minterfaceimpl.h"
 #include "mbed-trace/mbed_trace.h"
+
+#include <inttypes.h>
 
 #define TRACE_GROUP "mClt"
 
@@ -38,7 +47,7 @@ M2MInterface* M2MInterfaceFactory::create_interface(M2MInterfaceObserver &observ
     tr_debug("M2MInterfaceFactory::create_interface - IN");
     tr_debug("M2MInterfaceFactory::create_interface - parameters endpoint name : %s",endpoint_name.c_str());
     tr_debug("M2MInterfaceFactory::create_interface - parameters endpoint type : %s",endpoint_type.c_str());
-    tr_debug("M2MInterfaceFactory::create_interface - parameters life time(in secs):  %d",life_time);
+    tr_debug("M2MInterfaceFactory::create_interface - parameters life time(in secs): %" PRIu32,life_time);
     tr_debug("M2MInterfaceFactory::create_interface - parameters Listen Port : %d",listen_port);
     tr_debug("M2MInterfaceFactory::create_interface - parameters Binding Mode : %d",(int)mode);
     tr_debug("M2MInterfaceFactory::create_interface - parameters NetworkStack : %d",(int)stack);

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -1718,10 +1718,10 @@ bool M2MNsdlInterface::validate_security_object()
         uint32_t pkey_size = _security->get_resource(M2MSecurity::Secretkey)->value_length();
         tr_debug("M2MNsdlInterface::validate_security_object - Server URI /0/0: %s", address.c_str());
         tr_debug("M2MNsdlInterface::validate_security_object - is bs server /0/1: %d", is_bs_server);
-        tr_debug("M2MNsdlInterface::validate_security_object - Security Mode /0/2: %d", sec_mode);
-        tr_debug("M2MNsdlInterface::validate_security_object - Public key size /0/3: %d", public_key_size);
-        tr_debug("M2MNsdlInterface::validate_security_object - Server Public key size /0/4: %d", server_key_size);
-        tr_debug("M2MNsdlInterface::validate_security_object - Secret key size /0/5: %d", pkey_size);
+        tr_debug("M2MNsdlInterface::validate_security_object - Security Mode /0/2: %" PRIu32, sec_mode);
+        tr_debug("M2MNsdlInterface::validate_security_object - Public key size /0/3: %" PRIu32, public_key_size);
+        tr_debug("M2MNsdlInterface::validate_security_object - Server Public key size /0/4: %" PRIu32, server_key_size);
+        tr_debug("M2MNsdlInterface::validate_security_object - Secret key size /0/5: %" PRIu32, pkey_size);
         // Only NoSec and Certificate modes are supported
         if (!address.empty() && !is_bs_server) {
             if (M2MSecurity::Certificate == sec_mode) {


### PR DESCRIPTION
Use %PRIu32 instead of %d to print uint32_t as compiler expects.

Warnings being fixed:
---8<---8<----
[Warning] mbed_trace.h@115,90: format '%d' expects argument of type 'int',
but argument 4 has type 'uint32_t {aka long unsigned int}' [-Wformat=]
