### PR TITLE
Remove unnecessary includes of stdio.h, cstdio and stdexp

### DIFF
--- a/mbed-client/m2mconfig.h
+++ b/mbed-client/m2mconfig.h
@@ -20,10 +20,10 @@
 * \brief File defining all system build time configuration used by mbed-client.
 */
 
-#include <stdlib.h>
-#include <cstring>
-#include <cstdio>
 #include "mbed-client/m2mstring.h"
+
+#include <stddef.h>
+
 using namespace m2m;
 
 /**

--- a/mbed-client/m2mconnectionsecurity.h
+++ b/mbed-client/m2mconnectionsecurity.h
@@ -17,9 +17,13 @@
 #define __M2M_CONNECTION_SECURITY_H__
 
 #include "mbed-client/m2mconfig.h"
+
+#include <stdint.h>
+
 class M2MConnectionHandler;
 class M2MSecurity;
 class M2MConnectionSecurityPimpl;
+class M2MConnectionHandler;
 
 /*! \file m2mconnectionsecurity.h
  * \brief M2MConnectionSecurity.

--- a/mbed-client/m2mstring.h
+++ b/mbed-client/m2mstring.h
@@ -17,7 +17,6 @@
 #define M2M_STRING_H
 
 #include <stddef.h> // size_t
-#include <stdexcept>
 #include <stdint.h>
 
 class Test_M2MString;

--- a/mbed-client/m2mvector.h
+++ b/mbed-client/m2mvector.h
@@ -21,7 +21,6 @@
 * \brief A simple C++ Vector class, used as replacement for std::vector.
 */
 
-#include <stdio.h>
 
 namespace m2m
 {

--- a/source/m2mbase.cpp
+++ b/source/m2mbase.cpp
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define TRACE_GROUP "mClt"
 

--- a/source/m2mfirmware.cpp
+++ b/source/m2mfirmware.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cstdio>
+
 #include "mbed-client/m2mfirmware.h"
 #include "mbed-client/m2mconstants.h"
 #include "mbed-client/m2mobject.h"

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -26,6 +26,8 @@
 #include "mbed-client/m2mtimer.h"
 #include "mbed-trace/mbed_trace.h"
 
+#include <stdlib.h>
+
 #define TRACE_GROUP "mClt"
 
 M2MInterfaceImpl::M2MInterfaceImpl(M2MInterfaceObserver& observer,

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -44,6 +44,7 @@
 
 #include <assert.h>
 #include <inttypes.h>
+#include <stdlib.h>
 
 #define BUFFER_SIZE 21
 #define TRACE_GROUP "mClt"

--- a/source/m2mobject.cpp
+++ b/source/m2mobject.cpp
@@ -22,6 +22,8 @@
 #include "include/m2mreporthandler.h"
 #include "mbed-trace/mbed_trace.h"
 
+#include <stdlib.h>
+
 #define BUFFER_SIZE 10
 #define TRACE_GROUP "mClt"
 

--- a/source/m2mobjectinstance.cpp
+++ b/source/m2mobjectinstance.cpp
@@ -26,6 +26,8 @@
 #include "include/m2mreporthandler.h"
 #include "mbed-trace/mbed_trace.h"
 
+#include <stdlib.h>
+
 #define BUFFER_SIZE 10
 #define TRACE_GROUP "mClt"
 

--- a/source/m2mreporthandler.cpp
+++ b/source/m2mreporthandler.cpp
@@ -18,8 +18,8 @@
 #include "mbed-client/m2mtimer.h"
 #include "include/m2mreporthandler.h"
 #include "mbed-trace/mbed_trace.h"
-#include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define TRACE_GROUP "mClt"
 

--- a/source/m2mresource.cpp
+++ b/source/m2mresource.cpp
@@ -22,6 +22,8 @@
 #include "include/nsdllinker.h"
 #include "mbed-trace/mbed_trace.h"
 
+#include <stdlib.h>
+
 #define TRACE_GROUP "mClt"
 
 M2MResource& M2MResource::operator=(const M2MResource& other)

--- a/source/m2msecurity.cpp
+++ b/source/m2msecurity.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cstdio>
 #include "mbed-client/m2msecurity.h"
 #include "mbed-client/m2mconstants.h"
 #include "mbed-client/m2mobject.h"
@@ -21,6 +20,9 @@
 #include "mbed-client/m2mresource.h"
 #include "mbed-client/m2mstring.h"
 #include "mbed-trace/mbed_trace.h"
+
+#include <stdlib.h>
+
 #define TRACE_GROUP "mClt"
 
 #define BUFFER_SIZE 21

--- a/source/m2mserver.cpp
+++ b/source/m2mserver.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cstdio>
+
 #include "mbed-client/m2mserver.h"
 #include "mbed-client/m2mconstants.h"
 #include "mbed-client/m2mobject.h"

--- a/source/m2mtlvdeserializer.cpp
+++ b/source/m2mtlvdeserializer.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <stdio.h>
 #include "include/m2mtlvdeserializer.h"
 #include "mbed-client/m2mconstants.h"
 #include "include/nsdllinker.h"

--- a/source/m2mtlvserializer.cpp
+++ b/source/m2mtlvserializer.cpp
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <stdio.h>
 #include "include/m2mtlvserializer.h"
 #include "include/nsdllinker.h"
 #include "mbed-client/m2mconstants.h"
+
+#include <stdlib.h>
 
 #define TRACE_GROUP "mClt"
 

--- a/source/nsdlaccesshelper.cpp
+++ b/source/nsdlaccesshelper.cpp
@@ -16,6 +16,8 @@
 #include "include/nsdlaccesshelper.h"
 #include "include/m2mnsdlinterface.h"
 
+#include <stdlib.h>
+
 M2MNsdlInterfaceList __nsdl_interface_list;
 
 // callback function for NSDL library to call into

--- a/test/helloworld-mbedclient/main.cpp
+++ b/test/helloworld-mbedclient/main.cpp
@@ -22,6 +22,7 @@
 #include <stdarg.h>
 #include <pthread.h>
 #include <signal.h> /* For SIGIGN and SIGINT */
+#include <time.h>
 #else
 #include "sockets/UDPSocket.h"
 #ifdef SIXLOWPAN_INTERFACE

--- a/test/helloworld-mbedclient/mbedclient.cpp
+++ b/test/helloworld-mbedclient/mbedclient.cpp
@@ -26,6 +26,9 @@
 #include "test_env.h"
 #endif
 
+#include <time.h>
+#include <stdio.h>
+
 // Enter your mbed Device Server's IPv4 address and Port number in
 // mentioned format like 192.168.0.1:5693
 const String &BOOTSTRAP_SERVER_ADDRESS = "coap://10.45.3.10:5693";


### PR DESCRIPTION
The stdio related headers are causing headache on some
more constrained environments. Remove those as they are not
really even needed as one can and should be using the
eg. stdint and stdlib.
