### PR TITLE
Changed string allocation from static to dynamic in the unit tests

### DIFF
--- a/test/mbedclient/utest/m2minterfaceimpl/m2minterfaceimpltest.cpp
+++ b/test/mbedclient/utest/m2minterfaceimpl/m2minterfaceimpltest.cpp
@@ -16,19 +16,22 @@
 //CppUTest includes should be after your and system includes
 #include "CppUTest/TestHarness.h"
 #include "test_m2minterfaceimpl.h"
+#include "m2mnsdlinterface_stub.h"
 
 TEST_GROUP(M2MInterfaceImpl)
 {
-  Test_M2MInterfaceImpl* m2m_interface_impl;
+    Test_M2MInterfaceImpl* m2m_interface_impl;
 
-  void setup()
-  {
-    m2m_interface_impl = new Test_M2MInterfaceImpl();
-  }
-  void teardown()
-  {
-    delete m2m_interface_impl;
-  }
+    void setup()
+    {
+        m2mnsdlinterface_stub::string_value = new String();
+        m2m_interface_impl = new Test_M2MInterfaceImpl();
+    }
+    void teardown()
+    {
+        delete m2mnsdlinterface_stub::string_value;
+        delete m2m_interface_impl;
+    }
 };
 
 TEST(M2MInterfaceImpl, create)

--- a/test/mbedclient/utest/m2mobjectinstance/test_m2mobjectinstance.cpp
+++ b/test/mbedclient/utest/m2mobjectinstance/test_m2mobjectinstance.cpp
@@ -24,7 +24,7 @@
 #include "m2mreporthandler_stub.h"
 
 // Length is 65
-String max_length = "65656565656565656565656565656565656565656565656565656565656565656";
+String *max_length;
 
 class Handler : public M2MObservationHandler {
 
@@ -70,6 +70,7 @@ Test_M2MObjectInstance::Test_M2MObjectInstance()
     handler = new Handler();
     callback = new Callback();
     object = new M2MObjectInstance("name",*callback);
+    max_length = new String("65656565656565656565656565656565656565656565656565656565656565656");
 }
 
 void Test_M2MObjectInstance::test_copy_constructor()
@@ -95,6 +96,7 @@ Test_M2MObjectInstance::~Test_M2MObjectInstance()
     m2mbase_stub::clear();
     m2mtlvdeserializer_stub::clear();
     m2mtlvserializer_stub::clear();
+    delete max_length;
 
 }
 
@@ -117,7 +119,7 @@ void Test_M2MObjectInstance::test_create_static_resource()
     res = object->create_static_resource("","type",M2MResourceInstance::STRING,value,(u_int32_t)sizeof(value));
     CHECK(res == NULL);
 
-    res = object->create_static_resource(max_length,"type",M2MResourceInstance::STRING,value,(u_int32_t)sizeof(value));
+    res = object->create_static_resource(*max_length,"type",M2MResourceInstance::STRING,value,(u_int32_t)sizeof(value));
     CHECK(res == NULL);
 }
 
@@ -156,7 +158,7 @@ void Test_M2MObjectInstance::test_create_static_resource_instance()
 
     delete ins;
 
-    ins = object->create_static_resource_instance(max_length,"type",
+    ins = object->create_static_resource_instance(*max_length,"type",
                                                   M2MResourceInstance::STRING,value,
                                                   (u_int32_t)sizeof(value),0);
     CHECK(ins == NULL);
@@ -191,7 +193,7 @@ void Test_M2MObjectInstance::test_create_dynamic_resource_instance()
 
     CHECK(ins == NULL);
 
-    ins = object->create_dynamic_resource_instance(max_length,"type",
+    ins = object->create_dynamic_resource_instance(*max_length,"type",
                                                    M2MResourceInstance::STRING,
                                                    false,1);
     CHECK(ins == NULL);
@@ -217,7 +219,7 @@ void Test_M2MObjectInstance::test_create_dynamic_resource()
     M2MResource * res2 = object->create_dynamic_resource("","type",M2MResourceInstance::STRING,false,false);
     CHECK(res2 == NULL);
 
-    M2MResource * res3 = object->create_dynamic_resource(max_length,"type",M2MResourceInstance::STRING,false,false);
+    M2MResource * res3 = object->create_dynamic_resource(*max_length,"type",M2MResourceInstance::STRING,false,false);
     CHECK(res3 == NULL);
 }
 

--- a/test/mbedclient/utest/stub/m2mdevice_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mdevice_stub.cpp
@@ -18,23 +18,25 @@
 uint32_t m2mdevice_stub::int_value;
 bool m2mdevice_stub::bool_value;
 M2MResource* m2mdevice_stub::resource;
-String m2mdevice_stub::string_value;
+String *m2mdevice_stub::string_value;
 
 void m2mdevice_stub::clear()
 {
     int_value = -1;
     bool_value = false;
-    string_value = "";
+    *string_value = "";
     resource = NULL;
 }
 
 M2MDevice::M2MDevice()
 : M2MObject("3")
 {
+    m2mdevice_stub::string_value = new String("");
 }
 
 M2MDevice::~M2MDevice()
 {
+    delete m2mdevice_stub::string_value;
 }
 
 M2MDevice* M2MDevice::get_instance()
@@ -83,7 +85,7 @@ bool M2MDevice::set_resource_value(DeviceResource,
 String M2MDevice::resource_value_string(DeviceResource,
                                         uint16_t) const
 {
-    return m2mdevice_stub::string_value;
+    return *m2mdevice_stub::string_value;
 }
 
 int64_t M2MDevice::resource_value_int(DeviceResource,

--- a/test/mbedclient/utest/stub/m2mdevice_stub.h
+++ b/test/mbedclient/utest/stub/m2mdevice_stub.h
@@ -23,7 +23,7 @@ namespace m2mdevice_stub
 {
     extern uint32_t int_value;
     extern M2MResource* resource;
-    extern String string_value;
+    extern String *string_value;
     extern bool bool_value;
     void clear();
 }

--- a/test/mbedclient/utest/stub/m2mfirmware_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mfirmware_stub.cpp
@@ -18,13 +18,13 @@ bool m2mfirmware_stub::has_value;
 uint32_t m2mfirmware_stub::int_value;
 bool m2mfirmware_stub::bool_value;
 M2MResource* m2mfirmware_stub::resource;
-String m2mfirmware_stub::string_value;
+String *m2mfirmware_stub::string_value;
 
 void m2mfirmware_stub::clear()
 {
     int_value = -1;
     bool_value = false;
-    string_value = "";
+    *string_value = "";
     resource = NULL;
     has_value = false;
 }
@@ -32,10 +32,12 @@ void m2mfirmware_stub::clear()
 M2MFirmware::M2MFirmware()
 : M2MObject("5")
 {
+    m2mfirmware_stub::string_value = new String("");
 }
 
 M2MFirmware::~M2MFirmware()
 {
+    delete m2mfirmware_stub::string_value;
 }
 
 M2MFirmware* M2MFirmware::get_instance()
@@ -89,7 +91,7 @@ bool M2MFirmware::set_resource_value(FirmwareResource,
 
 String M2MFirmware::resource_value_string(FirmwareResource) const
 {
-    return m2mfirmware_stub::string_value;
+    return *m2mfirmware_stub::string_value;
 }
 
 int64_t M2MFirmware::resource_value_int(FirmwareResource) const

--- a/test/mbedclient/utest/stub/m2mfirmware_stub.h
+++ b/test/mbedclient/utest/stub/m2mfirmware_stub.h
@@ -23,7 +23,7 @@ namespace m2mfirmware_stub
 {
     extern uint32_t int_value;
     extern M2MResource* resource;
-    extern String string_value;
+    extern String *string_value;
     extern bool bool_value;
     void clear();
     extern bool has_value;

--- a/test/mbedclient/utest/stub/m2minterfaceimpl_stub.cpp
+++ b/test/mbedclient/utest/stub/m2minterfaceimpl_stub.cpp
@@ -17,14 +17,12 @@
 #include "common_stub.h"
 
 u_int8_t m2minterfaceimpl_stub::int_value;
-String m2minterfaceimpl_stub::string_value;
 bool m2minterfaceimpl_stub::bool_value;
 
 void m2minterfaceimpl_stub::clear()
 {
     int_value = 0;
     bool_value = false;
-    string_value = "";
 }
 
 M2MInterfaceImpl::M2MInterfaceImpl(M2MInterfaceObserver& observer,

--- a/test/mbedclient/utest/stub/m2minterfaceimpl_stub.h
+++ b/test/mbedclient/utest/stub/m2minterfaceimpl_stub.h
@@ -22,7 +22,6 @@
 namespace m2minterfaceimpl_stub
 {
     extern u_int8_t int_value;
-    extern String string_value;
     extern bool bool_value;
     void clear();
 }

--- a/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
@@ -19,22 +19,25 @@
 bool m2mnsdlinterface_stub::bool_value;
 uint32_t m2mnsdlinterface_stub::int_value;
 void * m2mnsdlinterface_stub::void_value;
-String m2mnsdlinterface_stub::string_value;
+String *m2mnsdlinterface_stub::string_value;
+
 void m2mnsdlinterface_stub::clear()
 {
     bool_value = false;
     int_value = 0;
-    string_value = "";
+    *string_value = "";
     void_value = NULL;
 }
 
 M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer)
 : _observer(observer)
 {
+    //m2mnsdlinterface_stub::string_value = new String("");
 }
 
 M2MNsdlInterface::~M2MNsdlInterface()
 {
+    //delete m2mnsdlinterface_stub::string_value;
 }
 
 bool M2MNsdlInterface::initialize()
@@ -197,5 +200,5 @@ void M2MNsdlInterface::handle_bootstrap_error()
 
 const String& M2MNsdlInterface::endpoint_name() const
 {
-    return m2mnsdlinterface_stub::string_value;
+    return *m2mnsdlinterface_stub::string_value;
 }

--- a/test/mbedclient/utest/stub/m2mnsdlinterface_stub.h
+++ b/test/mbedclient/utest/stub/m2mnsdlinterface_stub.h
@@ -24,7 +24,7 @@ namespace m2mnsdlinterface_stub
     extern bool bool_value;
     extern uint32_t int_value;
     extern void* void_value;
-    extern String string_value;
+    extern String *string_value;
     void clear();
 }
 

--- a/test/mbedclient/utest/stub/m2mserver_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mserver_stub.cpp
@@ -17,24 +17,26 @@
 
 uint32_t m2mserver_stub::int_value;
 bool m2mserver_stub::bool_value;
-String m2mserver_stub::string_value;
+String *m2mserver_stub::string_value;
 M2MResource* m2mserver_stub::resource;
 
 void m2mserver_stub::clear()
 {
     int_value = 0;
     bool_value = false;
-    string_value = "";
+    *string_value = "";
     resource = NULL;
 }
 
 M2MServer::M2MServer()
 : M2MObject("2")
 {
+    m2mserver_stub::string_value = new String("");
 }
 
 M2MServer::~M2MServer()
 {
+    delete m2mserver_stub::string_value;
 }
 
 M2MResource* M2MServer::create_resource(ServerResource, uint32_t)
@@ -66,7 +68,7 @@ bool M2MServer::set_resource_value(ServerResource,
 
 String M2MServer::resource_value_string(ServerResource) const
 {
-    return m2mserver_stub::string_value;
+    return *m2mserver_stub::string_value;
 }
 
 

--- a/test/mbedclient/utest/stub/m2mserver_stub.h
+++ b/test/mbedclient/utest/stub/m2mserver_stub.h
@@ -24,7 +24,7 @@ namespace m2mserver_stub
 {
     extern uint32_t int_value;
     extern bool bool_value;
-    extern String string_value;
+    extern String *string_value;
     extern M2MResource* resource;
     void clear();
 }


### PR DESCRIPTION
This was done to get rid of the valgrind errors.