### PR TITLE
Update mbed-client-classic.lib

### DIFF
--- a/mbed-client-classic.lib
+++ b/mbed-client-classic.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-client-classic/#656f13cd48640bce1f57f042eb2d735ddc48b315
+https://github.com/ARMmbed/mbed-client-classic/#42f18d977122acd4f5ad9ce141b74304b357dec2


### PR DESCRIPTION
Some devices currently have the limitation of not returning a valid address from a UDP receive. The PAL enforces a valid address if requested, causing the receive to fail.

Since client does not use the resulting address from receiveFrom, requesting an address is unnecessary. Removing the request allows client to support more, less-functional devices.