### PR TITLE
m2mbase: adapt to removal of resource_type_len

### DIFF
--- a/mbed-client/m2mbase.h
+++ b/mbed-client/m2mbase.h
@@ -484,6 +484,13 @@ protected:
     static void memory_free(void *ptr);
 
     /**
+     * \brief Allocate and make a copy of given zero terminated string. This
+     * is functionally equivalent with strdup().
+     * \param source The source string to copy, may not be NULL.
+    */
+    static char* alloc_string_copy(const char* source);
+
+    /**
      * \brief Allocate (size + 1) amount of memory, copy size bytes into
      * it and add zero termination.
      * \param source The source string to copy, may not be NULL.

--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -136,13 +136,13 @@ public:
      * @brief Memory Allocation required for libCoap.
      * @param size, Size of memory to be reserved.
     */
-    void* memory_alloc(uint16_t size);
+    static void* memory_alloc(uint16_t size);
 
     /**
      * @brief Memory free functions required for libCoap
      * @param ptr, Object whose memory needs to be freed.
     */
-    void memory_free(void *ptr);
+    static void memory_free(void *ptr);
 
     /**
     * @brief Callback from nsdl library to inform the data is ready
@@ -302,7 +302,7 @@ private:
      * @param source Source string to copy, may not be NULL.
      * @param size The size of memory to be reserved.
     */
-    uint8_t* alloc_string_copy(const uint8_t* source, uint16_t size);
+    static uint8_t* alloc_string_copy(const uint8_t* source, uint16_t size);
 
     /**
      * @brief Utility method to convert given lifetime int to ascii

--- a/source/m2mbase.cpp
+++ b/source/m2mbase.cpp
@@ -111,9 +111,7 @@ void M2MBase::set_interface_description(const char *desc)
     const size_t len = strlen(desc);
     if (len > 0 ) {
         _sn_resource->dynamic_resource_params->static_resource_parameters->interface_description_ptr =
-                alloc_string_copy((uint8_t*) desc, len);
-        _sn_resource->dynamic_resource_params->static_resource_parameters->interface_description_len =
-                len;
+                (char*)alloc_string_copy((uint8_t*) desc, len);
     }
 }
 

--- a/source/m2mbase.cpp
+++ b/source/m2mbase.cpp
@@ -136,10 +136,8 @@ void M2MBase::set_resource_type(const char *res_type)
     _sn_resource->dynamic_resource_params->static_resource_parameters->resource_type_ptr = NULL;
     const size_t len = strlen(res_type);
     if (len > 0) {
-        _sn_resource->dynamic_resource_params->static_resource_parameters->resource_type_ptr =
-                alloc_string_copy((uint8_t*) res_type,len);
-        _sn_resource->dynamic_resource_params->static_resource_parameters->resource_type_len =
-                len;
+        _sn_resource->dynamic_resource_params->static_resource_parameters->resource_type_ptr = (char*)
+                alloc_string_copy((uint8_t*) res_type, len);
     }
 }
 
@@ -378,6 +376,16 @@ void *M2MBase::memory_alloc(uint32_t size)
 void M2MBase::memory_free(void *ptr)
 {
     free(ptr);
+}
+
+char* M2MBase::alloc_string_copy(const char* source)
+{
+    assert(source != NULL);
+
+    // Note: the armcc's libc does not have strdup, so we need to implement it here
+    const size_t len = strlen(source);
+
+    return (char*)alloc_string_copy((uint8_t*)source, len);
 }
 
 uint8_t* M2MBase::alloc_string_copy(const uint8_t* source, uint32_t size)

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -1048,12 +1048,8 @@ bool M2MNsdlInterface::create_nsdl_resource(M2MBase *base, const String &name, b
             }
             if(base->interface_description() && _resource->static_resource_parameters) {
                 const size_t len = strlen(base->interface_description());
-                _resource->static_resource_parameters->interface_description_ptr =
-                        alloc_string_copy((uint8_t*)base->interface_description(),len);
-                if(_resource->static_resource_parameters->interface_description_ptr) {
-                    _resource->static_resource_parameters->interface_description_len =
-                            len;
-                 }
+                _resource->static_resource_parameters->interface_description_ptr = (char*)
+                        alloc_string_copy((uint8_t*)base->interface_description(), len);
             }
             if(_resource->static_resource_parameters) {
                 _resource->coap_content_type = base->coap_content_type();

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -1041,13 +1041,10 @@ bool M2MNsdlInterface::create_nsdl_resource(M2MBase *base, const String &name, b
                 }
             }
             if(base->resource_type() && _resource->static_resource_parameters) {
-                const size_t len = strlen(base->resource_type());
-                _resource->static_resource_parameters->resource_type_ptr =
-                        alloc_string_copy((uint8_t*)base->resource_type(),len);
-                if(_resource->static_resource_parameters->resource_type_ptr) {
-                    _resource->static_resource_parameters->resource_type_len =
-                           len;
-                }
+                // Note: this class could/should actually use the allocation helpers from M2MBase.
+                const size_t resource_type_len = strlen(base->resource_type());
+                _resource->static_resource_parameters->resource_type_ptr = (char*)
+                        alloc_string_copy((uint8_t*)base->resource_type(), resource_type_len);
             }
             if(base->interface_description() && _resource->static_resource_parameters) {
                 const size_t len = strlen(base->interface_description());


### PR DESCRIPTION
Since the mbed-client-c does not have a separate field for
length of resource_type_ptr, ie. the resource_type_len was removed,
we need to adapt to it.