### PR TITLE
Force publishing of device resource

### DIFF
--- a/source/m2mdevice.cpp
+++ b/source/m2mdevice.cpp
@@ -148,7 +148,9 @@ M2MResource* M2MDevice::create_resource(DeviceResource resource, const String &v
                     res->set_value((const uint8_t*)value.c_str(),
                                    (uint32_t)value.length());
                 }
-                res->set_register_uri(false);
+                // TODO - tihs might break spec, need to do more
+                // proper fix when time alllows (discovery?)
+                res->set_register_uri(true);
             }
         }
     }


### PR DESCRIPTION
To enable the update testing & development, it is not showing up in portal otherwise.
Ref: Marcus Chang / IOTCLT-1284

Note! This is NOT necessarily perhaps OMALWM2M compliant, so we need to come up with
a better fix when time allows (perhaps device discovery?)