### PR TITLE
m2minterafces: add path parameter to value_updated callbacks

### DIFF
--- a/mbed-client/m2minterfaceobserver.h
+++ b/mbed-client/m2minterfaceobserver.h
@@ -79,8 +79,9 @@ public:
      * \brief A callback indicating that the value of the resource object is updated by the server.
      * \param base The object whose value is updated.
      * \param type The type of the object.
+     * \param path The resource path (eg. "0/3/4") of resource being updated.
      */
-    virtual void value_updated(M2MBase *base, M2MBase::BaseType type) = 0;
+    virtual void value_updated(M2MBase *base, M2MBase::BaseType type, const char *path) = 0;
 };
 
 #endif // M2M_INTERFACE_OBSERVER_H

--- a/source/include/m2minterfaceimpl.h
+++ b/source/include/m2minterfaceimpl.h
@@ -201,7 +201,7 @@ protected: // From M2MNsdlObserver
 
     virtual void coap_data_processed();
 
-    virtual void value_updated(M2MBase *base);
+    virtual void value_updated(M2MBase *base, const char *path);
 
 protected: // From M2MConnectionObserver
 

--- a/source/include/m2mnsdlobserver.h
+++ b/source/include/m2mnsdlobserver.h
@@ -89,7 +89,8 @@ public :
     /**
      * @brief Callback informing that the value of the resource object is updated by server.
      * @param base Object whose value is updated.
+     * @param path The resource path (eg. "0/3/4") of resource being updated.
      */
-    virtual void value_updated(M2MBase *base) = 0;
+    virtual void value_updated(M2MBase *base, const char *path) = 0;
 };
 #endif // M2M_NSDL_OBSERVER_H

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -340,12 +340,12 @@ void M2MInterfaceImpl::coap_data_processed()
     internal_event(STATE_COAP_DATA_PROCESSED);
 }
 
-void M2MInterfaceImpl::value_updated(M2MBase *base)
+void M2MInterfaceImpl::value_updated(M2MBase *base, const char *path)
 {
-    tr_debug("M2MInterfaceImpl::value_updated(M2MBase *base)");
+    tr_debug("M2MInterfaceImpl::value_updated(%s)", path);
     if(base) {
         M2MBase::BaseType type = base->base_type();
-        _observer.value_updated(base, type);
+        _observer.value_updated(base, type, path);
     }
 }
 

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -464,6 +464,7 @@ uint8_t M2MNsdlInterface::received_from_server_callback(struct nsdl_s *nsdl_hand
             sn_coap_hdr_s *coap_response = NULL;
             bool execute_value_updated = false;
             M2MObjectInstance *obj_instance = NULL;
+            String resource_name;
 
             if(COAP_MSG_CODE_REQUEST_PUT == coap_header->msg_code) {
                 if (is_bootstrap_msg) {
@@ -493,7 +494,7 @@ uint8_t M2MNsdlInterface::received_from_server_callback(struct nsdl_s *nsdl_hand
                 }
                 else if(coap_header->uri_path_ptr) {
 
-                    String resource_name = coap_to_string(coap_header->uri_path_ptr,
+                    resource_name = coap_to_string(coap_header->uri_path_ptr,
                                                           coap_header->uri_path_len);
 
                     String object_name;
@@ -591,7 +592,7 @@ uint8_t M2MNsdlInterface::received_from_server_callback(struct nsdl_s *nsdl_hand
             }
 
             if (execute_value_updated) {
-                value_updated(obj_instance, obj_instance->name());
+                value_updated(obj_instance, resource_name);
             }
 
         }
@@ -820,7 +821,7 @@ void M2MNsdlInterface::value_updated(M2MBase *base,
         base->execute_value_updated(base->name());
     }
     else {
-        _observer.value_updated(base);
+        _observer.value_updated(base, object_name.c_str());
     }
 }
 


### PR DESCRIPTION
Add the path parameter containing the full resource path to
value_updated callbacks. This change is needed as the uri_path() was
removed from the M2MBase and the cloud client forwarding APIs
require that information to be available.

Note: this will break the client callback API and the client needs
to add ",const char *path" to their valued_updated() implementation
methods.