### PR TITLE
m2mfirmware: optionally constify the static structures

### DIFF
--- a/source/m2mfirmware.cpp
+++ b/source/m2mfirmware.cpp
@@ -55,7 +55,16 @@ M2MFirmware::~M2MFirmware()
 {
 }
 
+// Conditionally put the static part of parameter struct into flash.
+// Unfortunately this can't be done yet by default as there is old API which
+// may be used to modify the values in sn_nsdl_static_resource_parameters_s.
+#ifdef MEMORY_OPTIMIZED_API
+#define STATIC_PARAM_TYPE const
+#else
+#define STATIC_PARAM_TYPE
+#endif
 
+STATIC_PARAM_TYPE
 static sn_nsdl_static_resource_parameters_s firmware_package_params_static = {
     (char*)OMA_RESOURCE_TYPE,      // resource_type_ptr
     (char*)"",                     // interface_description_ptr
@@ -68,6 +77,7 @@ static sn_nsdl_static_resource_parameters_s firmware_package_params_static = {
     false                   // free_on_delete
 };
 
+STATIC_PARAM_TYPE
 static sn_nsdl_static_resource_parameters_s firmware_package_uri_params_static = {
     (char*)OMA_RESOURCE_TYPE,      // resource_type_ptr
     (char*)"",                     // interface_description_ptr
@@ -80,6 +90,7 @@ static sn_nsdl_static_resource_parameters_s firmware_package_uri_params_static =
     false                   // free_on_delete
 };
 
+STATIC_PARAM_TYPE
 static sn_nsdl_static_resource_parameters_s firmware_update_params_static = {
     (char*)OMA_RESOURCE_TYPE,   // resource_type_ptr
     (char*)"",                  // interface_description_ptr
@@ -92,6 +103,7 @@ static sn_nsdl_static_resource_parameters_s firmware_update_params_static = {
     false                   // free_on_delete
 };
 
+STATIC_PARAM_TYPE
 static sn_nsdl_static_resource_parameters_s firmware_state_params_static = {
     (char*)OMA_RESOURCE_TYPE,   // resource_type_ptr
     (char*)"",                  // interface_description_ptr
@@ -104,6 +116,7 @@ static sn_nsdl_static_resource_parameters_s firmware_state_params_static = {
     false                   // free_on_delete
 };
 
+STATIC_PARAM_TYPE
 static sn_nsdl_static_resource_parameters_s firmware_update_result_params_static = {
     (char*)OMA_RESOURCE_TYPE,      // resource_type_ptr
     (char*)"",                     // interface_description_ptr


### PR DESCRIPTION
If the old API is disabled by MEMORY_OPTIMIZED_API define,
we can put the sn_nsdl_static_resource_parameters_s structs
to flash to save some precious RAM.