### PR TITLE
m2mresources: remove unnecessary _object_name member

### DIFF
--- a/mbed-client/m2mresource.h
+++ b/mbed-client/m2mresource.h
@@ -50,8 +50,7 @@ private: // Constructor and destructor are private,
                  M2MObjectInstanceCallback &object_instance_callback,
                  const lwm2m_parameters_s* s,
                  M2MResourceInstance::ResourceType type,
-                 const uint16_t object_instance_id,
-                 const String &object_name);
+                 const uint16_t object_instance_id);
     /**
      * \brief Constructor
      * \param resource_name The resource name of the object.
@@ -73,7 +72,6 @@ private: // Constructor and destructor are private,
                 const uint8_t *value,
                 const uint8_t value_length,
                 const uint16_t object_instance_id = 0,
-                const String &object_name = "",
                 bool multiple_instance = false,
                 bool external_blockwise_store = false);
 
@@ -96,7 +94,6 @@ private: // Constructor and destructor are private,
                 M2MResourceInstance::ResourceType type,
                 bool observable,
                 const uint16_t object_instance_id = 0,
-                const String &object_name = "",
                 bool multiple_instance = false,
                 bool external_blockwise_store = false);
 
@@ -243,6 +240,12 @@ public:
                                                sn_nsdl_addr_s *address = NULL);
 
     M2MObjectInstance& get_parent_object_instance() const;
+
+    /**
+     * \brief Returns the name of the object where the resource exists.
+     * \return Object name.
+    */
+    virtual const char* object_name() const;
 
 protected:
     virtual void notification_update();

--- a/mbed-client/m2mresourceinstance.h
+++ b/mbed-client/m2mresourceinstance.h
@@ -73,8 +73,7 @@ private: // Constructor and destructor are private
                         const lwm2m_parameters_s* s,
                         M2MObjectInstanceCallback &object_instance_callback,
                         M2MResourceInstance::ResourceType type,
-                        const uint16_t object_instance_id,
-                        const String &object_name);
+                        const uint16_t object_instance_id);
     /**
      * \brief A constructor for creating a resource.
      * \param resource_name The name of the resource.
@@ -92,7 +91,6 @@ private: // Constructor and destructor are private
                         M2MResourceInstance::ResourceType type,
                         M2MObjectInstanceCallback &object_instance_callback,
                         const uint16_t object_instance_id,
-                        const String &object_name,
                         char* path,
                         bool external_blockwise_store);
 
@@ -118,7 +116,6 @@ private: // Constructor and destructor are private
                         const uint8_t value_length,
                         M2MObjectInstanceCallback &object_instance_callback,
                         const uint16_t object_instance_id,
-                        const String &object_name,
                         char* path,
                         bool external_blockwise_store);
 
@@ -264,7 +261,7 @@ public:
      * \brief Returns the name of the object where the resource exists.
      * \return Object name.
     */
-    const String& object_name() const;
+    virtual const char* object_name() const;
 
     /**
      * @brief Sets the function that is executed when this
@@ -332,7 +329,6 @@ private:
     M2MBlockMessage                         *_block_message_data;
     execute_callback                        _execute_callback;
     M2MResourceCallback                     *_resource_callback; // Not owned
-    String                                  _object_name;
     FP1<void, void*>                        *_execute_function_pointer;
     FP0<void>                               *_notification_sent_function_pointer;
     incoming_block_message_callback         _incoming_block_message_cb;

--- a/source/m2mobjectinstance.cpp
+++ b/source/m2mobjectinstance.cpp
@@ -82,7 +82,7 @@ M2MResource* M2MObjectInstance::create_static_resource(const lwm2m_parameters_s*
         return res;
     }
     if(!resource(static_res->name)) {
-        res = new M2MResource(*this, *this, static_res, type, (const uint16_t) M2MBase::instance_id(), M2MBase::name());
+        res = new M2MResource(*this, *this, static_res, type, (const uint16_t) M2MBase::instance_id());
         if(res) {
             res->add_observation_level(observation_level());
             //if (multiple_instance) {
@@ -110,7 +110,7 @@ M2MResource* M2MObjectInstance::create_static_resource(const String &resource_na
     if(!resource(resource_name)) {
         res = new M2MResource(*this, *this,resource_name, resource_type, type,
                               value, value_length, M2MBase::instance_id(),
-                              M2MBase::name(), multiple_instance, external_blockwise_store);
+                              multiple_instance, external_blockwise_store);
         if(res) {
             res->add_observation_level(observation_level());
             if (multiple_instance) {
@@ -133,7 +133,7 @@ M2MResource* M2MObjectInstance::create_dynamic_resource(const lwm2m_parameters_s
         return res;
     }
     if(!resource(static_res->name)) {
-        res = new M2MResource(*this, *this, static_res, type, M2MBase::instance_id(), M2MBase::name());
+        res = new M2MResource(*this, *this, static_res, type, M2MBase::instance_id());
         if(res) {
             //if (multiple_instance) { // TODO!
               //  res->set_coap_content_type(COAP_CONTENT_OMA_TLV_TYPE);
@@ -160,7 +160,7 @@ M2MResource* M2MObjectInstance::create_dynamic_resource(const String &resource_n
     if(!resource(resource_name)) {
         res = new M2MResource(*this, *this, resource_name, resource_type, type,
                               observable, M2MBase::instance_id(),
-                              M2MBase::name(), multiple_instance, external_blockwise_store);
+                              multiple_instance, external_blockwise_store);
         if(res) {
             if (multiple_instance) {
                 res->set_coap_content_type(COAP_CONTENT_OMA_TLV_TYPE);
@@ -190,7 +190,7 @@ M2MResourceInstance* M2MObjectInstance::create_static_resource_instance(const St
     if(!res) {
         res = new M2MResource(*this, *this,resource_name, resource_type, type,
                               value, value_length, M2MBase::instance_id(),
-                              M2MBase::name(), true, external_blockwise_store);
+                              true, external_blockwise_store);
         _resource_list.push_back(res);
         res->set_operation(M2MBase::GET_ALLOWED);
         res->set_observable(false);
@@ -200,7 +200,7 @@ M2MResourceInstance* M2MObjectInstance::create_static_resource_instance(const St
         char *path = M2MBase::create_path(*res, instance_id);
         instance = new M2MResourceInstance(*res, resource_name, resource_type, type,
                                            value, value_length, *this,
-                                           M2MBase::instance_id(), M2MBase::name(),
+                                           M2MBase::instance_id(),
                                            path, external_blockwise_store);
         if(instance) {
             instance->set_operation(M2MBase::GET_ALLOWED);
@@ -226,7 +226,7 @@ M2MResourceInstance* M2MObjectInstance::create_dynamic_resource_instance(const S
     M2MResource *res = resource(resource_name);
     if(!res) {
         res = new M2MResource(*this, *this,resource_name, resource_type, type,
-                              false, M2MBase::instance_id(), M2MBase::name(), true);
+                              false, M2MBase::instance_id(), true);
         _resource_list.push_back(res);
         res->set_register_uri(false);
         res->set_operation(M2MBase::GET_ALLOWED);
@@ -234,7 +234,7 @@ M2MResourceInstance* M2MObjectInstance::create_dynamic_resource_instance(const S
     if(res->supports_multiple_instances() && (res->resource_instance(instance_id) == NULL)) {
         char *path = create_path(*res, instance_id);
         instance = new M2MResourceInstance(*res, resource_name, resource_type, type, *this,
-                                           M2MBase::instance_id(), M2MBase::name(),
+                                           M2MBase::instance_id(),
                                            path, external_blockwise_store);
         if(instance) {
             instance->set_operation(M2MBase::GET_ALLOWED);

--- a/source/m2mresource.cpp
+++ b/source/m2mresource.cpp
@@ -33,11 +33,10 @@ M2MResource::M2MResource(M2MObjectInstance &parent,
                          const uint8_t *value,
                          const uint8_t value_length,
                          const uint16_t object_instance_id,
-                         const String &object_name,
                          bool multiple_instance,
                          bool external_blockwise_store)
 : M2MResourceInstance(*this, resource_name, resource_type, type, value, value_length,
-                      object_instance_callback, object_instance_id, object_name,
+                      object_instance_callback, object_instance_id,
                       create_path(parent, resource_name.c_str()), external_blockwise_store),
   _parent(parent),
   _delayed_token(NULL),
@@ -48,15 +47,15 @@ M2MResource::M2MResource(M2MObjectInstance &parent,
     M2MBase::set_base_type(M2MBase::Resource);
     M2MBase::set_operation(M2MBase::GET_ALLOWED);
     M2MBase::set_observable(false);
+
 }
 
 M2MResource::M2MResource(M2MObjectInstance &parent,
                          M2MObjectInstanceCallback &object_instance_callback,
                          const lwm2m_parameters_s* s,
                           M2MResourceInstance::ResourceType type,
-                         const uint16_t object_instance_id,
-                         const String &object_name)
-: M2MResourceInstance(*this, s, object_instance_callback, type, object_instance_id, object_name),
+                         const uint16_t object_instance_id)
+: M2MResourceInstance(*this, s, object_instance_callback, type, object_instance_id),
   _parent(parent),
   _delayed_token(NULL),
   _delayed_token_len(0),
@@ -73,11 +72,10 @@ M2MResource::M2MResource(M2MObjectInstance &parent,
                          M2MResourceInstance::ResourceType type,
                          bool observable,
                          const uint16_t object_instance_id,
-                         const String &object_name,
                          bool multiple_instance,
                          bool external_blockwise_store)
 : M2MResourceInstance(*this, resource_name, resource_type, type,
-                      object_instance_callback, object_instance_id, object_name,
+                      object_instance_callback, object_instance_id,
                       create_path(parent, resource_name.c_str()), external_blockwise_store),
   _parent(parent),
   _delayed_token(NULL),
@@ -569,6 +567,15 @@ M2MObjectInstance& M2MResource::get_parent_object_instance() const
 {
     return _parent;
 }
+
+const char* M2MResource::object_name() const
+{
+    const M2MObjectInstance& parent_object_instance = _parent;
+    const M2MObject& parent_object = parent_object_instance.get_parent_object();
+
+    return parent_object.name();
+}
+
 
 M2MResource::M2MExecuteParameter::M2MExecuteParameter()
 {

--- a/source/m2mresourceinstance.cpp
+++ b/source/m2mresourceinstance.cpp
@@ -17,6 +17,7 @@
 #include "mbed-client/m2mresource.h"
 #include "mbed-client/m2mconstants.h"
 #include "mbed-client/m2mobservationhandler.h"
+#include "mbed-client/m2mobject.h"
 #include "mbed-client/m2mobjectinstance.h"
 #include "include/m2mreporthandler.h"
 #include "include/nsdllinker.h"
@@ -31,7 +32,6 @@ M2MResourceInstance::M2MResourceInstance(M2MResource &parent,
                                          M2MResourceInstance::ResourceType type,
                                          M2MObjectInstanceCallback &object_instance_callback,
                                          const uint16_t object_instance_id,
-                                         const String &object_name,
                                          char* path,
                                          bool external_blockwise_store)
 : M2MBase(res_name,
@@ -45,7 +45,6 @@ M2MResourceInstance::M2MResourceInstance(M2MResource &parent,
  _block_message_data(NULL),
  _execute_callback(NULL),
  _resource_callback(NULL),
- _object_name(object_name),
  _execute_function_pointer(NULL),
  _notification_sent_function_pointer(NULL),
  _object_instance_callback(object_instance_callback),
@@ -64,7 +63,6 @@ M2MResourceInstance::M2MResourceInstance(M2MResource &parent,
                                          const uint8_t value_length,
                                          M2MObjectInstanceCallback &object_instance_callback,
                                          const uint16_t object_instance_id,
-                                         const String &object_name,
                                          char* path,
                                          bool external_blockwise_store)
 : M2MBase(res_name,
@@ -78,7 +76,6 @@ M2MResourceInstance::M2MResourceInstance(M2MResource &parent,
  _block_message_data(NULL),
  _execute_callback(NULL),
  _resource_callback(NULL),
- _object_name(object_name),
  _execute_function_pointer(NULL),
  _notification_sent_function_pointer(NULL),
  _object_instance_callback(object_instance_callback),
@@ -111,8 +108,7 @@ M2MResourceInstance::M2MResourceInstance(M2MResource &parent,
                                          const lwm2m_parameters_s* s,
                                          M2MObjectInstanceCallback &object_instance_callback,
                                          M2MResourceInstance::ResourceType type,
-                                         const uint16_t object_instance_id,
-                                         const String &object_name)
+                                         const uint16_t object_instance_id)
 : M2MBase(s),
   _parent_resource(parent),
   _value(NULL),
@@ -120,7 +116,6 @@ M2MResourceInstance::M2MResourceInstance(M2MResource &parent,
   _block_message_data(NULL),
   _execute_callback(NULL),
   _resource_callback(NULL),
-  _object_name(object_name),
   _execute_function_pointer(NULL),
   _notification_sent_function_pointer(NULL),
   _object_instance_callback(object_instance_callback),
@@ -555,11 +550,6 @@ void M2MResourceInstance::set_resource_observer(M2MResourceCallback *resource)
     _resource_callback = resource;
 }
 
-const String& M2MResourceInstance::object_name() const
-{
-    return _object_name;
-}
-
 uint16_t M2MResourceInstance::object_instance_id() const
 {
     return _object_instance_id;
@@ -607,4 +597,12 @@ void M2MResourceInstance::notification_sent()
 M2MResource& M2MResourceInstance::get_parent_resource() const
 {
     return _parent_resource;
+}
+
+const char* M2MResourceInstance::object_name() const
+{
+    const M2MObjectInstance& parent_object_instance = _parent_resource.get_parent_object_instance();
+    const M2MObject& parent_object = parent_object_instance.get_parent_object();
+
+    return parent_object.name();
 }


### PR DESCRIPTION
The object_name was stored as String on each resource instance
and resource. Since we now have pointers to parent, the object
name can be queried from the parent object itself instead of
storing a copy of it. This saves 12B plus heap space for name
itself per each resource(instance).