### PR TITLE
Fix nsdlinterface to use connectionhandler instance mutex

### DIFF
--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -33,6 +33,7 @@ class M2MResourceInstance;
 class M2MNsdlObserver;
 class M2MServer;
 class M2MTimer;
+class M2MConnectionHandler;
 
 typedef Vector<M2MObject *> M2MObjectList;
 
@@ -212,6 +213,11 @@ public:
      */
     const String& endpoint_name() const;
 
+    /**
+     * @brief Set the connection handler
+     */
+    void set_connection_handler(M2MConnectionHandler *connection_handler);
+
 protected: // from M2MTimerObserver
 
     virtual void timer_expired(M2MTimerObserver::Type type);
@@ -358,6 +364,16 @@ private:
     */
     void handle_bootstrap_error();
 
+    /**
+     * @brief Claim
+     */
+    void claim_mutex();
+
+    /**
+     * @brief Release
+     */
+    void release_mutex();
+
 private:
 
     M2MNsdlObserver                   &_observer;
@@ -366,6 +382,7 @@ private:
     M2MSecurity                       *_security; // Not owned
     M2MTimer                          *_nsdl_exceution_timer;
     M2MTimer                          *_registration_timer;
+    M2MConnectionHandler              *_connection_handler;
     sn_nsdl_ep_parameters_s           *_endpoint;
     sn_nsdl_resource_info_s           *_resource;
     sn_nsdl_addr_s                     _sn_nsdl_address;

--- a/source/include/nsdlaccesshelper.h
+++ b/source/include/nsdlaccesshelper.h
@@ -19,8 +19,6 @@
 #include "include/m2mnsdlinterface.h"
 
 typedef Vector<M2MNsdlInterface  *> M2MNsdlInterfaceList;
-extern M2MNsdlInterfaceList __nsdl_interface_list;
-extern M2MConnectionHandler *__connection_handler;
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,9 +43,6 @@ void *__socket_malloc( void * context, size_t size);
 void __socket_free(void * context, void * ptr);
 
 M2MNsdlInterface* get_interface(struct nsdl_s* nsdl_handle);
-
-void __mutex_claim();
-void __mutex_release();
 
 #ifdef __cplusplus
 }

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -84,7 +84,7 @@ M2MInterfaceImpl::M2MInterfaceImpl(M2MInterfaceObserver& observer,
     _security_connection = new M2MConnectionSecurity(sec_mode);
     //Here we must use TCP still
     _connection_handler = new M2MConnectionHandler(*this, _security_connection, mode, stack);
-    __connection_handler = _connection_handler;
+    _nsdl_interface->set_connection_handler(_connection_handler);
     _connection_handler->bind_connection(_listen_port);
 #ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
     _bootstrap_timer = new M2MTimer(*this);
@@ -99,7 +99,6 @@ M2MInterfaceImpl::~M2MInterfaceImpl()
     delete _queue_sleep_timer;
     delete _nsdl_interface;
     _connection_handler->stop_listening();
-    __connection_handler = NULL;
     delete _connection_handler;
     delete _retry_timer;
     delete _bootstrap_timer;

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -64,7 +64,6 @@ M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer)
   _identity_accepted(false)
 {
     tr_debug("M2MNsdlInterface::M2MNsdlInterface()");
-    __nsdl_interface_list.push_back(this);
     _sn_nsdl_address.addr_len = 0;
     _sn_nsdl_address.addr_ptr = NULL;
     _sn_nsdl_address.port = 0;
@@ -76,6 +75,7 @@ M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer)
     // and receiving purposes.
     _nsdl_handle = sn_nsdl_init(&(__nsdl_c_send_to_server), &(__nsdl_c_received_from_server),
                  &(__nsdl_c_memory_alloc), &(__nsdl_c_memory_free));
+    sn_nsdl_set_context(_nsdl_handle, this);
 
     _server = new M2MServer();
     initialize();
@@ -103,16 +103,6 @@ M2MNsdlInterface::~M2MNsdlInterface()
     sn_nsdl_destroy(_nsdl_handle);
     _nsdl_handle = NULL;
 
-    M2MNsdlInterfaceList::const_iterator it;
-    it = __nsdl_interface_list.begin();
-    int index = 0;
-    for (; it!=__nsdl_interface_list.end(); it++) {
-        if ((*it) == this) {
-            __nsdl_interface_list.erase(index);
-            break;
-        }
-        index++;
-    }
     tr_debug("M2MNsdlInterface::~M2MNsdlInterface() - OUT");
 }
 

--- a/source/nsdlaccesshelper.cpp
+++ b/source/nsdlaccesshelper.cpp
@@ -19,9 +19,6 @@
 #include <stdlib.h>
 
 // callback function for NSDL library to call into
-M2MConnectionHandler *__connection_handler = NULL;
-
-
 uint8_t __nsdl_c_callback(struct nsdl_s *nsdl_handle,
                           sn_coap_hdr_s *received_coap_ptr,
                           sn_nsdl_addr_s *address,
@@ -104,16 +101,3 @@ void __socket_free(void * context, void * ptr)
     free(ptr);
 }
 
-void __mutex_claim()
-{
-    if(__connection_handler) {
-        __connection_handler->claim_mutex();
-    }
-}
-
-void __mutex_release()
-{
-    if(__connection_handler) {
-        __connection_handler->release_mutex();
-    }
-}

--- a/source/nsdlaccesshelper.cpp
+++ b/source/nsdlaccesshelper.cpp
@@ -18,10 +18,7 @@
 
 #include <stdlib.h>
 
-M2MNsdlInterfaceList __nsdl_interface_list;
-
 // callback function for NSDL library to call into
-
 M2MConnectionHandler *__connection_handler = NULL;
 
 
@@ -31,7 +28,7 @@ uint8_t __nsdl_c_callback(struct nsdl_s *nsdl_handle,
                           sn_nsdl_capab_e nsdl_capab)
 {
     uint8_t status = 0;
-    M2MNsdlInterface  *interface = get_interface(nsdl_handle);
+    M2MNsdlInterface *interface = (M2MNsdlInterface*)sn_nsdl_get_context(nsdl_handle);
     if(interface) {
         status = interface->resource_callback(nsdl_handle,received_coap_ptr,
                                                      address, nsdl_capab);
@@ -65,7 +62,7 @@ uint8_t __nsdl_c_send_to_server(struct nsdl_s * nsdl_handle,
                                 sn_nsdl_addr_s *address_ptr)
 {
     uint8_t status = 0;
-    M2MNsdlInterface  *interface = get_interface(nsdl_handle);
+    M2MNsdlInterface *interface = (M2MNsdlInterface*)sn_nsdl_get_context(nsdl_handle);
     if(interface) {
         status = interface->send_to_server_callback(nsdl_handle,
                                                            protocol, data_ptr,
@@ -79,7 +76,7 @@ uint8_t __nsdl_c_received_from_server(struct nsdl_s * nsdl_handle,
                                       sn_nsdl_addr_s *address_ptr)
 {
     uint8_t status = 0;
-    M2MNsdlInterface  *interface = get_interface(nsdl_handle);
+    M2MNsdlInterface *interface = (M2MNsdlInterface*)sn_nsdl_get_context(nsdl_handle);
     if(interface) {
         status = interface->received_from_server_callback(nsdl_handle,
                                                                  coap_header,
@@ -105,22 +102,6 @@ void __socket_free(void * context, void * ptr)
 {
     (void) context;
     free(ptr);
-}
-
-M2MNsdlInterface* get_interface(struct nsdl_s* nsdl_handle)
-{
-    M2MNsdlInterfaceList::const_iterator it;
-    it = __nsdl_interface_list.begin();
-    M2MNsdlInterface* obj = NULL;
-    if (nsdl_handle) {
-        for (; it!=__nsdl_interface_list.end(); it++) {
-            if ((*it)->get_nsdl_handle() == nsdl_handle) {
-                obj = *it;
-                break;
-            }
-        }
-    }
-    return obj;
 }
 
 void __mutex_claim()

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
@@ -26,8 +26,12 @@
 #include "m2mbase_stub.h"
 #include "m2mserver.h"
 #include "m2msecurity.h"
+#include "m2mconnectionsecurity.h"
 #include "m2mtlvdeserializer_stub.h"
-class TestObserver : public M2MNsdlObserver {
+#include "m2mconnectionhandler_stub.h"
+#include "m2mconnectionsecurity_stub.h"
+class TestObserver : public M2MNsdlObserver,
+                     public M2MConnectionObserver {
 
 public:
     TestObserver(){}
@@ -80,6 +84,26 @@ public:
 
     void value_updated(M2MBase *){
         value_update = true;
+    }
+
+    void data_available(uint8_t* data,
+                        uint16_t data_size,
+                        const M2MConnectionObserver::SocketAddress &address){
+
+    }
+
+    void socket_error(uint8_t error_code, bool retry = true){
+
+    }
+
+    void address_ready(const M2MConnectionObserver::SocketAddress &address,
+                                   M2MConnectionObserver::ServerType server_type,
+                                   const uint16_t server_port){
+
+    }
+
+    void data_sent(){
+
     }
 
     bool register_error;
@@ -1791,6 +1815,28 @@ void Test_M2MNsdlInterface::test_get_nsdl_handle()
 {
     CHECK(nsdl->get_nsdl_handle() == nsdl->_nsdl_handle);
 }
+
+void Test_M2MNsdlInterface::test_set_connection_handler()
+{
+    CHECK(nsdl->_connection_handler == NULL);
+    M2MConnectionSecurity *sec = new M2MConnectionSecurity(M2MConnectionSecurity::NO_SECURITY);
+    M2MConnectionHandler *connhandler = new M2MConnectionHandler(*observer, sec, M2MInterface::UDP, M2MInterface::LwIP_IPv4);
+    nsdl->set_connection_handler(connhandler);
+    CHECK(nsdl->_connection_handler == connhandler);
+}
+
+void Test_M2MNsdlInterface::test_claim_release_mutex()
+{
+    M2MConnectionSecurity *sec = new M2MConnectionSecurity(M2MConnectionSecurity::NO_SECURITY);
+    M2MConnectionHandler *connhandler = new M2MConnectionHandler(*observer, sec, M2MInterface::UDP, M2MInterface::LwIP_IPv4);
+    nsdl->set_connection_handler(connhandler);
+    CHECK(m2mconnectionhandler_stub::mutex_count == 0);
+    nsdl->claim_mutex();
+    CHECK(m2mconnectionhandler_stub::mutex_count == 1);
+    nsdl->release_mutex();
+    CHECK(m2mconnectionhandler_stub::mutex_count == 0);
+}
+
 
 void Test_M2MNsdlInterface::test_endpoint_name()
 {

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
@@ -88,6 +88,10 @@ public:
 
     void test_get_nsdl_handle();
 
+    void test_set_connection_handler();
+
+    void test_claim_release_mutex();
+
     void test_endpoint_name();
 
     M2MNsdlInterface* nsdl;

--- a/test/mbedclient/utest/nsdlaccesshelper/nsdlaccesshelpertest.cpp
+++ b/test/mbedclient/utest/nsdlaccesshelper/nsdlaccesshelpertest.cpp
@@ -73,12 +73,3 @@ TEST(NsdlAccessHelper, test_socket_free)
     nsdl->test_socket_free();
 }
 
-TEST(NsdlAccessHelper, test_mutex_claim)
-{
-    nsdl->test_mutex_claim();
-}
-
-TEST(NsdlAccessHelper, test_mutex_release)
-{
-    nsdl->test_mutex_release();
-}

--- a/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.cpp
+++ b/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.cpp
@@ -208,28 +208,6 @@ void Test_NsdlAccessHelper::test_socket_free()
     //No need to check anything, since memory leak is the test
 }
 
-void Test_NsdlAccessHelper::test_mutex_claim()
-{
-    __connection_handler = new M2MConnectionHandler(*observer,
-                                                    NULL,
-                                                    M2MInterface::UDP,
-                                                    M2MInterface::LwIP_IPv4);
-    __mutex_claim();
-
-    delete __connection_handler;
-}
-
-void Test_NsdlAccessHelper::test_mutex_release()
-{
-    __connection_handler = new M2MConnectionHandler(*observer,
-                                                    NULL,
-                                                    M2MInterface::UDP,
-                                                    M2MInterface::LwIP_IPv4);
-    __mutex_release();
-
-    delete __connection_handler;
-}
-
 void Test_NsdlAccessHelper::clear_list()
 {
     M2MNsdlInterfaceList::const_iterator it;

--- a/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.h
+++ b/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.h
@@ -42,10 +42,6 @@ public:
 
     void test_socket_free();
 
-    void test_mutex_claim();
-
-    void test_mutex_release();
-
     TestObserver *observer;
 private:
     void clear_list();

--- a/test/mbedclient/utest/stub/m2mconnectionhandler_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mconnectionhandler_stub.cpp
@@ -20,12 +20,15 @@
 int m2mconnectionhandler_stub::int_value;
 uint16_t m2mconnectionhandler_stub::uint_value;
 bool m2mconnectionhandler_stub::bool_value;
+int m2mconnectionhandler_stub::mutex_count;
 
 void m2mconnectionhandler_stub::clear()
 {
     int_value = -1;
     uint_value = 0;
     bool_value = false;
+    mutex_count = 0;
+
 }
 
 M2MConnectionHandler::M2MConnectionHandler(M2MConnectionObserver &observer,
@@ -87,8 +90,12 @@ void M2MConnectionHandler::set_platform_network_handler(void *)
 
 void M2MConnectionHandler::claim_mutex()
 {
+    printf("XXXXXXXXXXXXXXXXX");
+    m2mconnectionhandler_stub::mutex_count++;
 }
 
 void M2MConnectionHandler::release_mutex()
 {
+    printf("YYYYYYYYYYYYYYYYY");
+    m2mconnectionhandler_stub::mutex_count--;
 }

--- a/test/mbedclient/utest/stub/m2mconnectionhandler_stub.h
+++ b/test/mbedclient/utest/stub/m2mconnectionhandler_stub.h
@@ -24,6 +24,7 @@ namespace m2mconnectionhandler_stub
     extern int int_value;
     extern uint16_t uint_value;
     extern bool bool_value;
+    extern int mutex_count;
     void clear();
 }
 

--- a/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
@@ -197,6 +197,17 @@ void M2MNsdlInterface::handle_bootstrap_error()
 {
 
 }
+void M2MNsdlInterface::claim_mutex()
+{
+}
+
+void M2MNsdlInterface::release_mutex()
+{
+}
+
+void M2MNsdlInterface::set_connection_handler(M2MConnectionHandler *connection_handler)
+{
+}
 
 const String& M2MNsdlInterface::endpoint_name() const
 {

--- a/test/mbedclient/utest/stub/nsdlaccesshelper_stub.cpp
+++ b/test/mbedclient/utest/stub/nsdlaccesshelper_stub.cpp
@@ -74,10 +74,3 @@ void __socket_free(void *, void *)
 {
 }
 
-void __mutex_claim()
-{
-}
-
-void __mutex_release()
-{
-}


### PR DESCRIPTION
Changed global __connection_handler variable to be a member of
M2MNsdlInterface and added an API to set connection handler.
This allows each M2MNsdlInterface instance use the same mutex
as the connection handler that is associated with it.