### PR TITLE
Replace memcmp_equal macro with strcmp_equal in m2mbase alloc_copy te…

### DIFF
--- a/test/mbedclient/utest/m2mbase/test_m2mbase.cpp
+++ b/test/mbedclient/utest/m2mbase/test_m2mbase.cpp
@@ -499,8 +499,9 @@ void Test_M2MBase::test_is_integer()
 void Test_M2MBase::test_alloc_copy()
 {
     uint8_t* test_ptr = (uint8_t *)malloc(10);
+    memset(test_ptr,'a', 10);
     uint8_t* result = alloc_copy(test_ptr, 10);
-    MEMCMP_EQUAL(result,test_ptr,10);
+    STRCMP_EQUAL((char*)test_ptr,(char*)result);
     free(test_ptr);
     free(result);
 }


### PR DESCRIPTION
…st. MEMCMP is intoruduced in CppUTest V3.7