### PR TITLE
m2mresource: save RAM and ROM at M2MExecuteParameter

### DIFF
--- a/mbed-client/m2mresource.h
+++ b/mbed-client/m2mresource.h
@@ -295,14 +295,16 @@ class M2MResource::M2MExecuteParameter {
 private:
 
     /**
-     * \brief Constructor
+     * \brief Constructor, since there is no implementation, it prevents invalid use of it
      */
     M2MExecuteParameter();
 
-    /**
-     * Destructor
-     */
-   ~M2MExecuteParameter();
+#ifdef MEMORY_OPTIMIZED_API
+    M2MExecuteParameter(const char *object_name, const char *resource_name, uint16_t object_instance_id);
+#else
+    // This is a deprecated constructor, to be removed on next release.
+    M2MExecuteParameter(const String &object_name, const String &resource_name, uint16_t object_instance_id);
+#endif
 
 public:
 
@@ -310,7 +312,7 @@ public:
      * \brief Returns the value of an argument.
      * \return uint8_t * The argument value.
      */
-    uint8_t *get_argument_value() const;
+    const uint8_t *get_argument_value() const;
 
     /**
      * \brief Returns the length of the value argument.
@@ -322,13 +324,21 @@ public:
      * \brief Returns the name of the object where the resource exists.
      * \return Object name.
     */
+#ifdef MEMORY_OPTIMIZED_API
+    const char* get_argument_object_name() const;
+#else
     const String& get_argument_object_name() const;
+#endif
 
     /**
      * \brief Returns the resource name.
      * \return Resource name.
     */
+#ifdef MEMORY_OPTIMIZED_API
+    const char* get_argument_resource_name() const;
+#else
     const String& get_argument_resource_name() const;
+#endif
 
     /**
      * \brief Returns the instance ID of the object where the resource exists.
@@ -337,13 +347,19 @@ public:
     uint16_t get_argument_object_instance_id() const;
 
 private:
+    // pointers to const data, not owned by this instance
 
-    String      _object_name;
-    String      _resource_name;
-    uint8_t *   _value;
-    uint16_t    _value_length;
-    uint16_t    _object_instance_id;
+#ifdef MEMORY_OPTIMIZED_API
+    const char      *_object_name;
+    const char      *_resource_name;
+#else
+    const String    &_object_name;
+    const String    &_resource_name;
+#endif
 
+    const uint8_t   *_value;
+    uint16_t        _value_length;
+    uint16_t        _object_instance_id;
 
 friend class Test_M2MResource;
 friend class M2MResource;

--- a/test/mbedclient/utest/m2mresource/test_m2mresource.cpp
+++ b/test/mbedclient/utest/m2mresource/test_m2mresource.cpp
@@ -645,21 +645,35 @@ void Test_M2MResource::test_delayed_response()
 
 void Test_M2MResource::test_execute_params()
 {
-    M2MResource::M2MExecuteParameter *params = new M2MResource::M2MExecuteParameter();
+    // Note: we need to use const name&objname here as the params is just storing references
+    // so passing dummy "" or "object" there will cause segfault when the value is being verified.
+    const String empty_name("");
+    const String empty_object_name("");
+    
+    M2MResource::M2MExecuteParameter *params = new M2MResource::M2MExecuteParameter(empty_name, empty_object_name, 0);
+
     CHECK(params->get_argument_value() == NULL);
     CHECK(params->get_argument_value_length() == 0);
     CHECK(params->get_argument_object_name() == "");
     CHECK(params->get_argument_resource_name() == "");
     CHECK(params->get_argument_object_instance_id() == 0);
 
-    uint8_t value[] = {"test"};
+    const uint8_t value[] = {"testvalue"};
     int length = sizeof(value);
-    params->_value = (uint8_t*)malloc(length);
-    memcpy(params->_value,value,length);
+    uint8_t* temp_value = (uint8_t*)malloc(length);
+    memcpy(temp_value, value, length);
+
+    delete params;
+
+    // then test with something more than just empty values
+    const String param_name("object");
+    const String param_object_name("resource");
+    
+    params = new M2MResource::M2MExecuteParameter(param_name, param_object_name, 1);
+    params->_value = temp_value;
     params->_value_length = length;
-    params->_object_name = "object";
-    params->_resource_name = "resource";
-    params->_object_instance_id = 0;
+    params->_object_instance_id = 7;
+    
     CHECK(params->_value == params->get_argument_value());
     CHECK(params->_value_length == params->get_argument_value_length());
     CHECK(params->_resource_name == params->get_argument_resource_name());
@@ -667,6 +681,8 @@ void Test_M2MResource::test_execute_params()
     CHECK(params->_object_instance_id == params->get_argument_object_instance_id());
 
     delete params;
+
+    free(temp_value);
 }
 
 void Test_M2MResource::test_ctor()


### PR DESCRIPTION
Change the API, use and internal storage of M2MExecuteParameter.
No need to allocate temp object from heap and copy the value just
for the duration of execute callback. This also reduces code
footprint by 120B on GCC.

Note: this changes the user facing API.