### PR TITLE
Nsdl interface list removal and mutex

### DIFF
--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -34,6 +34,7 @@ class M2MResourceInstance;
 class M2MNsdlObserver;
 class M2MServer;
 class M2MTimer;
+class M2MConnectionHandler;
 
 typedef Vector<M2MObject *> M2MObjectList;
 
@@ -213,6 +214,11 @@ public:
      */
     const String& endpoint_name() const;
 
+    /**
+     * @brief Set the connection handler
+     */
+    void set_connection_handler(M2MConnectionHandler *connection_handler);
+
 protected: // from M2MTimerObserver
 
     virtual void timer_expired(M2MTimerObserver::Type type);
@@ -355,6 +361,16 @@ private:
     */
     void handle_bootstrap_error();
 
+    /**
+     * @brief Claim
+     */
+    void claim_mutex();
+
+    /**
+     * @brief Release
+     */
+    void release_mutex();
+
 private:
 
     M2MNsdlObserver                         &_observer;
@@ -365,6 +381,7 @@ private:
     M2MServer                               _server;
     M2MTimer                                *_nsdl_exceution_timer;
     M2MTimer                                *_registration_timer;
+    M2MConnectionHandler                    *_connection_handler;
     sn_nsdl_addr_s                          _sn_nsdl_address;
     String                                  _endpoint_name;
     uint32_t                                _counter_for_nsdl;

--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -57,7 +57,7 @@ public:
     * @brief Constructor
     * @param observer, Observer to pass the event callbacks from nsdl library.
     */
-    M2MNsdlInterface(M2MNsdlObserver &observer);
+    M2MNsdlInterface(M2MNsdlObserver &observer, M2MConnectionHandler &connection_handler);
 
     /**
      * @brief Destructor
@@ -213,11 +213,6 @@ public:
      * @return endpoint name
      */
     const String& endpoint_name() const;
-
-    /**
-     * @brief Set the connection handler
-     */
-    void set_connection_handler(M2MConnectionHandler *connection_handler);
 
 protected: // from M2MTimerObserver
 
@@ -381,7 +376,7 @@ private:
     M2MServer                               _server;
     M2MTimer                                *_nsdl_exceution_timer;
     M2MTimer                                *_registration_timer;
-    M2MConnectionHandler                    *_connection_handler;
+    M2MConnectionHandler                    &_connection_handler;
     sn_nsdl_addr_s                          _sn_nsdl_address;
     String                                  _endpoint_name;
     uint32_t                                _counter_for_nsdl;

--- a/source/include/nsdlaccesshelper.h
+++ b/source/include/nsdlaccesshelper.h
@@ -19,8 +19,6 @@
 #include "include/m2mnsdlinterface.h"
 
 typedef Vector<M2MNsdlInterface  *> M2MNsdlInterfaceList;
-extern M2MNsdlInterfaceList __nsdl_interface_list;
-extern M2MConnectionHandler *__connection_handler;
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,9 +43,6 @@ void *__socket_malloc( void * context, size_t size);
 void __socket_free(void * context, void * ptr);
 
 M2MNsdlInterface* get_interface(struct nsdl_s* nsdl_handle);
-
-void __mutex_claim();
-void __mutex_release();
 
 #ifdef __cplusplus
 }

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -78,7 +78,7 @@ M2MInterfaceImpl::M2MInterfaceImpl(M2MInterfaceObserver& observer,
                                      _context_address);
 
     //Here we must use TCP still
-    __connection_handler = &_connection_handler;
+    _nsdl_interface.set_connection_handler(&_connection_handler);
     _connection_handler.bind_connection(_listen_port);
 #ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
     _bootstrap_timer = new M2MTimer(*this);

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -66,7 +66,7 @@ M2MInterfaceImpl::M2MInterfaceImpl(M2MInterfaceObserver& observer,
   _observer(observer),
   _security_connection( new M2MConnectionSecurity( RESOLVE_SEC_MODE(mode) )),
   _connection_handler(*this, _security_connection, mode, stack),
-  _nsdl_interface(*this),
+  _nsdl_interface(*this, _connection_handler),
   _security(NULL)
 {
     tr_debug("M2MInterfaceImpl::M2MInterfaceImpl() -IN");
@@ -78,7 +78,6 @@ M2MInterfaceImpl::M2MInterfaceImpl(M2MInterfaceObserver& observer,
                                      _context_address);
 
     //Here we must use TCP still
-    _nsdl_interface.set_connection_handler(&_connection_handler);
     _connection_handler.bind_connection(_listen_port);
 #ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
     _bootstrap_timer = new M2MTimer(*this);

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -63,7 +63,6 @@ M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer)
   _identity_accepted(false)
 {
     tr_debug("M2MNsdlInterface::M2MNsdlInterface()");
-    __nsdl_interface_list.push_back(this);
     _sn_nsdl_address.addr_len = 0;
     _sn_nsdl_address.addr_ptr = NULL;
     _sn_nsdl_address.port = 0;
@@ -75,6 +74,7 @@ M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer)
     // and receiving purposes.
     _nsdl_handle = sn_nsdl_init(&(__nsdl_c_send_to_server), &(__nsdl_c_received_from_server),
                  &(__nsdl_c_memory_alloc), &(__nsdl_c_memory_free));
+    sn_nsdl_set_context(_nsdl_handle, this);
 
     initialize();
 }
@@ -96,16 +96,6 @@ M2MNsdlInterface::~M2MNsdlInterface()
     sn_nsdl_destroy(_nsdl_handle);
     _nsdl_handle = NULL;
 
-    M2MNsdlInterfaceList::const_iterator it;
-    it = __nsdl_interface_list.begin();
-    int index = 0;
-    for (; it!=__nsdl_interface_list.end(); it++) {
-        if ((*it) == this) {
-            __nsdl_interface_list.erase(index);
-            break;
-        }
-        index++;
-    }
     tr_debug("M2MNsdlInterface::~M2MNsdlInterface() - OUT");
 }
 

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -49,7 +49,7 @@
 #define BUFFER_SIZE 21
 #define TRACE_GROUP "mClt"
 
-M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer)
+M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer, M2MConnectionHandler &connection_handler)
 : _observer(observer),
   _endpoint(NULL),
   _nsdl_handle(NULL),
@@ -57,7 +57,7 @@ M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer)
   _server(),
   _nsdl_exceution_timer(new M2MTimer(*this)),
   _registration_timer(new M2MTimer(*this)),
-  _connection_handler(NULL),
+  _connection_handler(connection_handler),
   _counter_for_nsdl(0),
   _bootstrap_id(0),
   _unregister_ongoing(false),
@@ -97,7 +97,6 @@ M2MNsdlInterface::~M2MNsdlInterface()
     sn_nsdl_destroy(_nsdl_handle);
     _nsdl_handle = NULL;
 
-    _connection_handler = NULL;
     tr_debug("M2MNsdlInterface::~M2MNsdlInterface() - OUT");
 }
 
@@ -1641,23 +1640,14 @@ void M2MNsdlInterface::handle_bootstrap_error()
     _observer.bootstrap_error();
 }
 
-void M2MNsdlInterface::set_connection_handler(M2MConnectionHandler *connection_handler)
-{
-    _connection_handler = connection_handler;
-}
-
 void M2MNsdlInterface::claim_mutex()
 {
-    if (_connection_handler) {
-        _connection_handler->claim_mutex();
-    }
+    _connection_handler.claim_mutex();
 }
 
 void M2MNsdlInterface::release_mutex()
 {
-    if (_connection_handler) {
-        _connection_handler->release_mutex();
-    }
+    _connection_handler.release_mutex();
 }
 
 const String& M2MNsdlInterface::endpoint_name() const

--- a/source/nsdlaccesshelper.cpp
+++ b/source/nsdlaccesshelper.cpp
@@ -19,9 +19,6 @@
 #include <stdlib.h>
 
 // callback function for NSDL library to call into
-M2MConnectionHandler *__connection_handler = NULL;
-
-
 uint8_t __nsdl_c_callback(struct nsdl_s *nsdl_handle,
                           sn_coap_hdr_s *received_coap_ptr,
                           sn_nsdl_addr_s *address,
@@ -104,16 +101,3 @@ void __socket_free(void * context, void * ptr)
     free(ptr);
 }
 
-void __mutex_claim()
-{
-    if(__connection_handler) {
-        __connection_handler->claim_mutex();
-    }
-}
-
-void __mutex_release()
-{
-    if(__connection_handler) {
-        __connection_handler->release_mutex();
-    }
-}

--- a/source/nsdlaccesshelper.cpp
+++ b/source/nsdlaccesshelper.cpp
@@ -18,10 +18,7 @@
 
 #include <stdlib.h>
 
-M2MNsdlInterfaceList __nsdl_interface_list;
-
 // callback function for NSDL library to call into
-
 M2MConnectionHandler *__connection_handler = NULL;
 
 
@@ -31,7 +28,7 @@ uint8_t __nsdl_c_callback(struct nsdl_s *nsdl_handle,
                           sn_nsdl_capab_e nsdl_capab)
 {
     uint8_t status = 0;
-    M2MNsdlInterface  *interface = get_interface(nsdl_handle);
+    M2MNsdlInterface *interface = (M2MNsdlInterface*)sn_nsdl_get_context(nsdl_handle);
     if(interface) {
         status = interface->resource_callback(nsdl_handle,received_coap_ptr,
                                                      address, nsdl_capab);
@@ -65,7 +62,7 @@ uint8_t __nsdl_c_send_to_server(struct nsdl_s * nsdl_handle,
                                 sn_nsdl_addr_s *address_ptr)
 {
     uint8_t status = 0;
-    M2MNsdlInterface  *interface = get_interface(nsdl_handle);
+    M2MNsdlInterface *interface = (M2MNsdlInterface*)sn_nsdl_get_context(nsdl_handle);
     if(interface) {
         status = interface->send_to_server_callback(nsdl_handle,
                                                            protocol, data_ptr,
@@ -79,7 +76,7 @@ uint8_t __nsdl_c_received_from_server(struct nsdl_s * nsdl_handle,
                                       sn_nsdl_addr_s *address_ptr)
 {
     uint8_t status = 0;
-    M2MNsdlInterface  *interface = get_interface(nsdl_handle);
+    M2MNsdlInterface *interface = (M2MNsdlInterface*)sn_nsdl_get_context(nsdl_handle);
     if(interface) {
         status = interface->received_from_server_callback(nsdl_handle,
                                                                  coap_header,
@@ -105,22 +102,6 @@ void __socket_free(void * context, void * ptr)
 {
     (void) context;
     free(ptr);
-}
-
-M2MNsdlInterface* get_interface(struct nsdl_s* nsdl_handle)
-{
-    M2MNsdlInterfaceList::const_iterator it;
-    it = __nsdl_interface_list.begin();
-    M2MNsdlInterface* obj = NULL;
-    if (nsdl_handle) {
-        for (; it!=__nsdl_interface_list.end(); it++) {
-            if ((*it)->get_nsdl_handle() == nsdl_handle) {
-                obj = *it;
-                break;
-            }
-        }
-    }
-    return obj;
 }
 
 void __mutex_claim()

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
@@ -149,14 +149,16 @@ struct nsdl_s {
 Test_M2MNsdlInterface::Test_M2MNsdlInterface()
 {
     observer = new TestObserver();
-    nsdl = new M2MNsdlInterface(*observer);
-    //nsdl->_server = new M2MServer();
+    connection_handler = new M2MConnectionHandler(*observer, NULL, M2MInterface::NOT_SET, M2MInterface::Uninitialized);
+    nsdl = new M2MNsdlInterface(*observer, *connection_handler);
 }
 
 Test_M2MNsdlInterface:: ~Test_M2MNsdlInterface()
 {
     delete nsdl;
     nsdl = NULL;
+    delete connection_handler;
+    connection_handler = NULL;
     delete observer;
     observer = NULL;
 }
@@ -1815,20 +1817,8 @@ void Test_M2MNsdlInterface::test_get_nsdl_handle()
     CHECK(nsdl->get_nsdl_handle() == nsdl->_nsdl_handle);
 }
 
-void Test_M2MNsdlInterface::test_set_connection_handler()
-{
-    CHECK(nsdl->_connection_handler == NULL);
-    M2MConnectionSecurity *sec = new M2MConnectionSecurity(M2MConnectionSecurity::NO_SECURITY);
-    M2MConnectionHandler *connhandler = new M2MConnectionHandler(*observer, sec, M2MInterface::UDP, M2MInterface::LwIP_IPv4);
-    nsdl->set_connection_handler(connhandler);
-    CHECK(nsdl->_connection_handler == connhandler);
-}
-
 void Test_M2MNsdlInterface::test_claim_release_mutex()
 {
-    M2MConnectionSecurity *sec = new M2MConnectionSecurity(M2MConnectionSecurity::NO_SECURITY);
-    M2MConnectionHandler *connhandler = new M2MConnectionHandler(*observer, sec, M2MInterface::UDP, M2MInterface::LwIP_IPv4);
-    nsdl->set_connection_handler(connhandler);
     CHECK(m2mconnectionhandler_stub::mutex_count == 0);
     nsdl->claim_mutex();
     CHECK(m2mconnectionhandler_stub::mutex_count == 1);

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
@@ -84,6 +84,10 @@ public:
 
     void test_get_nsdl_handle();
 
+    void test_set_connection_handler();
+
+    void test_claim_release_mutex();
+
     void test_endpoint_name();
 
     M2MNsdlInterface* nsdl;

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
@@ -93,6 +93,8 @@ public:
     M2MNsdlInterface* nsdl;
 
     TestObserver *observer;
+
+    M2MConnectionHandler *connection_handler;
 };
 
 #endif // TEST_M2M_NSDL_INTERFACE_H

--- a/test/mbedclient/utest/nsdlaccesshelper/nsdlaccesshelpertest.cpp
+++ b/test/mbedclient/utest/nsdlaccesshelper/nsdlaccesshelpertest.cpp
@@ -73,12 +73,3 @@ TEST(NsdlAccessHelper, test_socket_free)
     nsdl->test_socket_free();
 }
 
-TEST(NsdlAccessHelper, test_mutex_claim)
-{
-    nsdl->test_mutex_claim();
-}
-
-TEST(NsdlAccessHelper, test_mutex_release)
-{
-    nsdl->test_mutex_release();
-}

--- a/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.cpp
+++ b/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.cpp
@@ -105,10 +105,13 @@ public:
 Test_NsdlAccessHelper::Test_NsdlAccessHelper()
 {
     observer = new TestObserver();
+    connection_handler = new M2MConnectionHandler(*observer, NULL, M2MInterface::NOT_SET, M2MInterface::Uninitialized);
 }
 
 Test_NsdlAccessHelper::~Test_NsdlAccessHelper()
 {
+    delete connection_handler;
+    connection_handler = NULL;
     delete observer;
     observer = NULL;
 }
@@ -120,7 +123,7 @@ void Test_NsdlAccessHelper::test_nsdl_c_callback()
 
     m2mnsdlinterface_stub::int_value = 1;
     m2mnsdlinterface_stub::void_value = malloc(1);
-    common_stub::void_value = new M2MNsdlInterface(*observer);
+    common_stub::void_value = new M2MNsdlInterface(*observer, *connection_handler);
     common_stub::coap_header = (sn_coap_hdr_s *) malloc(sizeof(sn_coap_hdr_s));
     memset(common_stub::coap_header, 0, sizeof(sn_coap_hdr_s));
     common_stub::coap_header->options_list_ptr = (sn_coap_options_list_s *) malloc(sizeof(sn_coap_options_list_s));
@@ -161,7 +164,7 @@ void Test_NsdlAccessHelper::test_nsdl_c_send_to_server()
     common_stub::void_value = NULL;
     CHECK(__nsdl_c_send_to_server(NULL, SN_NSDL_PROTOCOL_HTTP, NULL, 0, NULL) == 0);
 
-    common_stub::void_value = new M2MNsdlInterface(*observer);
+    common_stub::void_value = new M2MNsdlInterface(*observer, *connection_handler);
     CHECK(__nsdl_c_send_to_server(NULL, SN_NSDL_PROTOCOL_HTTP, NULL, 0, NULL) == 1);
 
     m2mnsdlinterface_stub::int_value = 1;
@@ -177,7 +180,7 @@ void Test_NsdlAccessHelper::test_nsdl_c_received_from_server()
     common_stub::void_value = NULL;
     CHECK( 0 == __nsdl_c_received_from_server(NULL, NULL, NULL));
 
-    common_stub::void_value = new M2MNsdlInterface(*observer);
+    common_stub::void_value = new M2MNsdlInterface(*observer, *connection_handler);
     CHECK( 0 == __nsdl_c_received_from_server(NULL, NULL, NULL));
 
     m2mnsdlinterface_stub::int_value = 1;

--- a/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.cpp
+++ b/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.cpp
@@ -111,18 +111,16 @@ Test_NsdlAccessHelper::~Test_NsdlAccessHelper()
 {
     delete observer;
     observer = NULL;
-
-    clear_list();
 }
 
 void Test_NsdlAccessHelper::test_nsdl_c_callback()
 {
+    common_stub::void_value = NULL;
     CHECK(__nsdl_c_callback(NULL,NULL,NULL,SN_NSDL_PROTOCOL_HTTP) == 0 );
 
     m2mnsdlinterface_stub::int_value = 1;
     m2mnsdlinterface_stub::void_value = malloc(1);
-    __nsdl_interface_list.clear();
-    __nsdl_interface_list.push_back(new M2MNsdlInterface(*observer));
+    common_stub::void_value = new M2MNsdlInterface(*observer);
     common_stub::coap_header = (sn_coap_hdr_s *) malloc(sizeof(sn_coap_hdr_s));
     memset(common_stub::coap_header, 0, sizeof(sn_coap_hdr_s));
     common_stub::coap_header->options_list_ptr = (sn_coap_options_list_s *) malloc(sizeof(sn_coap_options_list_s));
@@ -132,8 +130,8 @@ void Test_NsdlAccessHelper::test_nsdl_c_callback()
                             common_stub::coap_header,NULL,SN_NSDL_PROTOCOL_HTTP) == 1 );
     free(common_stub::coap_header->options_list_ptr);
     free(common_stub::coap_header);
+    delete (M2MNsdlInterface*)common_stub::void_value;
     free(m2mnsdlinterface_stub::void_value);
-    clear_list();
 }
 
 void Test_NsdlAccessHelper::test_nsdl_c_memory_alloc()
@@ -160,26 +158,30 @@ void Test_NsdlAccessHelper::test_nsdl_c_memory_free()
 
 void Test_NsdlAccessHelper::test_nsdl_c_send_to_server()
 {
+    common_stub::void_value = NULL;
     CHECK(__nsdl_c_send_to_server(NULL, SN_NSDL_PROTOCOL_HTTP, NULL, 0, NULL) == 0);
+
+    common_stub::void_value = new M2MNsdlInterface(*observer);
+    CHECK(__nsdl_c_send_to_server(NULL, SN_NSDL_PROTOCOL_HTTP, NULL, 0, NULL) == 1);
 
     m2mnsdlinterface_stub::int_value = 1;
     m2mnsdlinterface_stub::void_value = malloc(1);
-    __nsdl_interface_list.clear();
-    __nsdl_interface_list.push_back(new M2MNsdlInterface(*observer));
 
     CHECK(__nsdl_c_send_to_server((nsdl_s*)m2mnsdlinterface_stub::void_value, SN_NSDL_PROTOCOL_HTTP, NULL, 0, NULL) == 1);
     free(m2mnsdlinterface_stub::void_value);
-    clear_list();
+    delete (M2MNsdlInterface*)common_stub::void_value;
 }
 
 void Test_NsdlAccessHelper::test_nsdl_c_received_from_server()
 {
+    common_stub::void_value = NULL;
+    CHECK( 0 == __nsdl_c_received_from_server(NULL, NULL, NULL));
+
+    common_stub::void_value = new M2MNsdlInterface(*observer);
     CHECK( 0 == __nsdl_c_received_from_server(NULL, NULL, NULL));
 
     m2mnsdlinterface_stub::int_value = 1;
     m2mnsdlinterface_stub::void_value = malloc(1);
-    __nsdl_interface_list.clear();
-    __nsdl_interface_list.push_back(new M2MNsdlInterface(*observer));
     common_stub::coap_header = (sn_coap_hdr_s *) malloc(sizeof(sn_coap_hdr_s));
     memset(common_stub::coap_header, 0, sizeof(sn_coap_hdr_s));
     common_stub::coap_header->options_list_ptr = (sn_coap_options_list_s *) malloc(sizeof(sn_coap_options_list_s));
@@ -187,8 +189,8 @@ void Test_NsdlAccessHelper::test_nsdl_c_received_from_server()
     CHECK( 1 == __nsdl_c_received_from_server((nsdl_s*)m2mnsdlinterface_stub::void_value, common_stub::coap_header, NULL));
     free(common_stub::coap_header->options_list_ptr);
     free(common_stub::coap_header);
+    delete (M2MNsdlInterface*)common_stub::void_value;
     free(m2mnsdlinterface_stub::void_value);
-    clear_list();
 }
 
 void Test_NsdlAccessHelper::test_socket_malloc()
@@ -208,16 +210,3 @@ void Test_NsdlAccessHelper::test_socket_free()
     //No need to check anything, since memory leak is the test
 }
 
-void Test_NsdlAccessHelper::clear_list()
-{
-    M2MNsdlInterfaceList::const_iterator it;
-    it = __nsdl_interface_list.begin();
-    int size = __nsdl_interface_list.size();
-    if (!__nsdl_interface_list.empty()) {
-        for (int i = 0; i < size; i++) {
-                delete __nsdl_interface_list[i];
-                __nsdl_interface_list.erase(i);
-            }
-        __nsdl_interface_list.clear();
-    }
-}

--- a/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.cpp
+++ b/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.cpp
@@ -208,28 +208,6 @@ void Test_NsdlAccessHelper::test_socket_free()
     //No need to check anything, since memory leak is the test
 }
 
-void Test_NsdlAccessHelper::test_mutex_claim()
-{
-    __connection_handler = new M2MConnectionHandler(*observer,
-                                                    NULL,
-                                                    M2MInterface::UDP,
-                                                    M2MInterface::LwIP_IPv4);
-    __mutex_claim();
-
-    delete __connection_handler;
-}
-
-void Test_NsdlAccessHelper::test_mutex_release()
-{
-    __connection_handler = new M2MConnectionHandler(*observer,
-                                                    NULL,
-                                                    M2MInterface::UDP,
-                                                    M2MInterface::LwIP_IPv4);
-    __mutex_release();
-
-    delete __connection_handler;
-}
-
 void Test_NsdlAccessHelper::clear_list()
 {
     M2MNsdlInterfaceList::const_iterator it;

--- a/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.h
+++ b/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.h
@@ -42,10 +42,6 @@ public:
 
     void test_socket_free();
 
-    void test_mutex_claim();
-
-    void test_mutex_release();
-
     TestObserver *observer;
 private:
     void clear_list();

--- a/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.h
+++ b/test/mbedclient/utest/nsdlaccesshelper/test_nsdlaccesshelper.h
@@ -43,6 +43,7 @@ public:
     void test_socket_free();
 
     TestObserver *observer;
+    M2MConnectionHandler *connection_handler;
 private:
     void clear_list();
 };

--- a/test/mbedclient/utest/stub/common_stub.cpp
+++ b/test/mbedclient/utest/stub/common_stub.cpp
@@ -95,6 +95,16 @@ struct nsdl_s *sn_nsdl_init	(uint8_t (*sn_nsdl_tx_cb)(struct nsdl_s *, sn_nsdl_c
     return NULL;
 }
 
+int8_t sn_nsdl_set_context(struct nsdl_s * const handle, void * const context)
+{
+    return common_stub::int_value;
+}
+
+void *sn_nsdl_get_context(const struct nsdl_s * const handle)
+{
+    return common_stub::void_value;
+}
+
 uint16_t sn_nsdl_register_endpoint(struct nsdl_s *, sn_nsdl_ep_parameters_s *)
 {
     return common_stub::uint_value;

--- a/test/mbedclient/utest/stub/m2mconnectionhandler_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mconnectionhandler_stub.cpp
@@ -20,6 +20,7 @@
 int m2mconnectionhandler_stub::int_value;
 uint16_t m2mconnectionhandler_stub::uint_value;
 bool m2mconnectionhandler_stub::bool_value;
+int m2mconnectionhandler_stub::mutex_count;
 M2MConnectionSecurity* secu = NULL;
 
 void m2mconnectionhandler_stub::clear()
@@ -27,6 +28,8 @@ void m2mconnectionhandler_stub::clear()
     int_value = -1;
     uint_value = 0;
     bool_value = false;
+    mutex_count = 0;
+
 }
 
 M2MConnectionHandler::M2MConnectionHandler(M2MConnectionObserver &observer,
@@ -93,8 +96,10 @@ void M2MConnectionHandler::set_platform_network_handler(void *)
 
 void M2MConnectionHandler::claim_mutex()
 {
+    m2mconnectionhandler_stub::mutex_count++;
 }
 
 void M2MConnectionHandler::release_mutex()
 {
+    m2mconnectionhandler_stub::mutex_count--;
 }

--- a/test/mbedclient/utest/stub/m2mconnectionhandler_stub.h
+++ b/test/mbedclient/utest/stub/m2mconnectionhandler_stub.h
@@ -24,6 +24,7 @@ namespace m2mconnectionhandler_stub
     extern int int_value;
     extern uint16_t uint_value;
     extern bool bool_value;
+    extern int mutex_count;
     void clear();
 }
 

--- a/test/mbedclient/utest/stub/m2minterfaceimpl_stub.cpp
+++ b/test/mbedclient/utest/stub/m2minterfaceimpl_stub.cpp
@@ -39,10 +39,10 @@ M2MInterfaceImpl::M2MInterfaceImpl(M2MInterfaceObserver& observer,
   _max_states( STATE_MAX_STATES ),
   _event_generated(false),
   _event_data(NULL),
-  _nsdl_interface(*this),
   _queue_sleep_timer(*this),
   _retry_timer(*this),
-  _connection_handler(*this, NULL, mode, stack)
+  _connection_handler(*this, NULL, mode, stack),
+  _nsdl_interface(*this, _connection_handler)
 {
 }
 

--- a/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "m2mnsdlinterface_stub.h"
-
+#include "m2mconnectionhandler_stub.h"
 
 bool m2mnsdlinterface_stub::bool_value;
 uint32_t m2mnsdlinterface_stub::int_value;
@@ -29,8 +29,8 @@ void m2mnsdlinterface_stub::clear()
     void_value = NULL;
 }
 
-M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer)
-: _observer(observer)
+M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer, M2MConnectionHandler &connection_handler)
+: _observer(observer), _connection_handler(connection_handler)
 {
     //m2mnsdlinterface_stub::string_value = new String("");
 }
@@ -202,10 +202,6 @@ void M2MNsdlInterface::claim_mutex()
 }
 
 void M2MNsdlInterface::release_mutex()
-{
-}
-
-void M2MNsdlInterface::set_connection_handler(M2MConnectionHandler *connection_handler)
 {
 }
 

--- a/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
@@ -197,6 +197,17 @@ void M2MNsdlInterface::handle_bootstrap_error()
 {
 
 }
+void M2MNsdlInterface::claim_mutex()
+{
+}
+
+void M2MNsdlInterface::release_mutex()
+{
+}
+
+void M2MNsdlInterface::set_connection_handler(M2MConnectionHandler *connection_handler)
+{
+}
 
 const String& M2MNsdlInterface::endpoint_name() const
 {

--- a/test/mbedclient/utest/stub/nsdlaccesshelper_stub.cpp
+++ b/test/mbedclient/utest/stub/nsdlaccesshelper_stub.cpp
@@ -74,10 +74,3 @@ void __socket_free(void *, void *)
 {
 }
 
-void __mutex_claim()
-{
-}
-
-void __mutex_release()
-{
-}


### PR DESCRIPTION
Removes the global nsdl_interface list and use new context parameter in sn_nsdl library to determine which interface context to work in. 

Removes the global __connection_handler variable. Instead pass connection handler instance to the nsdlinterface and use the mutex methods from there.