### PR TITLE
Allow setting server uri with buffer and length

### DIFF
--- a/source/m2msecurity.cpp
+++ b/source/m2msecurity.cpp
@@ -210,7 +210,8 @@ bool M2MSecurity::set_resource_value(SecurityResource resource,
     if(res) {
         if(M2MSecurity::PublicKey == resource           ||
            M2MSecurity::ServerPublicKey == resource     ||
-           M2MSecurity::Secretkey == resource) {
+           M2MSecurity::Secretkey == resource           ||
+           M2MSecurity::M2MServerUri == resource) {
             success = res->set_value(value,length);
         }
     }

--- a/test/mbedclient/utest/m2msecurity/test_m2msecurity.cpp
+++ b/test/mbedclient/utest/m2msecurity/test_m2msecurity.cpp
@@ -183,7 +183,7 @@ void Test_M2MSecurity::test_set_resource_value_buffer()
     CHECK(security->set_resource_value(M2MSecurity::ServerPublicKey,value,length) == true);
     CHECK(security->set_resource_value(M2MSecurity::PublicKey,value,length) == true);
 
-    CHECK(security->set_resource_value(M2MSecurity::M2MServerUri,value,length) == false);
+    CHECK(security->set_resource_value(M2MSecurity::M2MServerUri,value,length) == true);
     CHECK(security->set_resource_value(M2MSecurity::SMSBindingKey,value,length) == false);
     CHECK(security->set_resource_value(M2MSecurity::SMSBindingSecretKey,value,length) == false);
     CHECK(security->set_resource_value(M2MSecurity::BootstrapServer,value,length) == false);


### PR DESCRIPTION
This would allow using just buffer and length to set server uri resource value, no need for temporary String variable when for example reading from configuration.