### PR TITLE
Add mbed-client-c to mbed-client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,32 +5,33 @@ SET(CMAKE_SYSTEM_NAME Generic)
 
 project(mbedClient)
 
-set(port_libs_PATH ${CMAKE_CURRENT_SOURCE_DIR}/port_libs/)
+set(port_libs_PATH ${CMAKE_CURRENT_SOURCE_DIR}/port_libs)
 #own include dirs
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/source)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-classic/)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-mbed-tls/)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-c)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-classic)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-mbed-tls)
 
 
 #pal include Dirs
-set(PAL_APIS_INCLUDE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../mbed-client-pal/Source/PAL-Impl/Services-API/)
+set(PAL_APIS_INCLUDE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../mbed-client-pal/Source/PAL-Impl/Services-API)
 include_directories(${PAL_APIS_INCLUDE_PATH}/)
 SET(PAL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../mbed-client-pal/Source)
 #need to make this platform
 include_directories(${PAL_SOURCE_DIR}/Port/Reference-Impl/Linux/CFStore)
-include_directories(${PAL_SOURCE_DIR}/Port/Platform-API/)
+include_directories(${PAL_SOURCE_DIR}/Port/Platform-API)
+
+set(MBED_CLIENT_C_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-c)
 
 #porting libs
 include_directories(${port_libs_PATH}/nanostack-libservice/mbed-client-libservice)
 include_directories(${port_libs_PATH}/nanostack-libservice/)
 include_directories(${port_libs_PATH}/sal-stack-nanostack-eventloop/nanostack-event-loop)
-include_directories(${port_libs_PATH}/ns-hal-pal/)
-include_directories(${port_libs_PATH}/mbed-client-c/)
-include_directories(${port_libs_PATH}/mbed-trace/)
+include_directories(${port_libs_PATH}/ns-hal-pal)
+include_directories(${port_libs_PATH}/mbed-trace)
 
 
-set(MBED_CLIENT_C_PATH ${CMAKE_CURRENT_SOURCE_DIR}/port_libs/mbed-client-c)
 set(SAL_NANOSTACK_EVENT_LOOP_PATH ${CMAKE_CURRENT_SOURCE_DIR}/port_libs/sal-stack-nanostack-eventloop)
 set(RANDLIB_C_PATH ${CMAKE_CURRENT_SOURCE_DIR}/port_libs/mbed-client-randlib)
 set(NANOSTACK_LIBSERVICE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/port_libs/nanostack-libservice)
@@ -38,38 +39,38 @@ set(NS_HAL_PAL_PATH ${CMAKE_CURRENT_SOURCE_DIR}/port_libs/ns-hal-pal)
 set(MBED_COAP_PATH ${CMAKE_CURRENT_SOURCE_DIR}/port_libs/mbed-coap)
 
 include_directories(${MBED_COAP_PATH})
-include_directories(${MBED_COAP_PATH}/mbed-coap/)
-include_directories(${MBED_COAP_PATH}/source/include/)
+include_directories(${MBED_COAP_PATH}/mbed-coap)
+include_directories(${MBED_COAP_PATH}/source/include)
 
 
 include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH})
-include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/nanostack-event-loop/)
-include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/nanostack-event-loop/platform/)
-include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/source/libNsdl/src/include/)
-include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/source/libCoap/src/)
-include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/source/libCoap/src/include/)
+include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/nanostack-event-loop)
+include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/nanostack-event-loop/platform)
+include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/source/libNsdl/src/include)
+include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/source/libCoap/src)
+include_directories(${SAL_NANOSTACK_EVENT_LOOP_PATH}/source/libCoap/src/include)
 
 
 include_directories(${MBED_CLIENT_C_PATH})
-include_directories(${MBED_CLIENT_C_PATH}/nsdl-c/)
-include_directories(${MBED_CLIENT_C_PATH}/source/include/)
+include_directories(${MBED_CLIENT_C_PATH}/nsdl-c)
+include_directories(${MBED_CLIENT_C_PATH}/source/include)
 
 include_directories(${RANDLIB_C_PATH}/mbed-client-randlib)
-include_directories(${RANDLIB_C_PATH}/mbed-client-randlib/platform/)
+include_directories(${RANDLIB_C_PATH}/mbed-client-randlib/platform)
 
 include_directories(${NANOSTACK_LIBSERVICE_PATH}/)
-include_directories(${NANOSTACK_LIBSERVICE_PATH}/mbed-client-libservice/)
-include_directories(${NANOSTACK_LIBSERVICE_PATH}/mbed-client-libservice/platform/)
+include_directories(${NANOSTACK_LIBSERVICE_PATH}/mbed-client-libservice)
+include_directories(${NANOSTACK_LIBSERVICE_PATH}/mbed-client-libservice/platform)
 
 
 include_directories(${NS_HAL_PAL_PATH})
 
 
-set(PAL_HEADER_API ${NS_HAL_PAL_PATH}/../../mbed-client-pal/Source/)
-include_directories(${PAL_HEADER_API}/PAL-Impl/Services-API/)
+set(PAL_HEADER_API ${NS_HAL_PAL_PATH}/../../mbed-client-pal/Source)
+include_directories(${PAL_HEADER_API}/PAL-Impl/Services-API)
 #need to make this platform
 include_directories(${PAL_HEADER_API}/Port/Reference-Impl/Linux/CFStore)
-include_directories(${PAL_HEADER_API}/Port/Platform-API/)
+include_directories(${PAL_HEADER_API}/Port/Platform-API)
 
 include_directories(${PAL_HEADER_API})
 

--- a/mbed-client-c.lib
+++ b/mbed-client-c.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/mbed-client-c/#c739b8cbcc57d7eab34a176179131f33b4436658

--- a/mbed-client-classic.lib
+++ b/mbed-client-classic.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-client-classic/#612d27a2e8c7fde693c3a6d87deca6d6960d390d
+https://github.com/ARMmbed/mbed-client-classic/#b9a521dcd0fc0e076a3746fc3544da05faa5577a

--- a/port_libs/mbed-client-c.ref
+++ b/port_libs/mbed-client-c.ref
@@ -1,1 +1,0 @@
-git@github.com:ARMmbed/mbed-client-c.git#master


### PR DESCRIPTION
Adding mbed-client-c (without mbed-coap) to mbed-client to pull in
all dependencies for applications due to coap-separation change
in mbedOS 5.4.