### PR TITLE
Moving observation parameters from M2MBase to M2MReportHandler

### DIFF
--- a/mbed-client/m2mbase.h
+++ b/mbed-client/m2mbase.h
@@ -486,6 +486,7 @@ public:
 protected : // from M2MReportObserver
 
     virtual void observation_to_be_sent(m2m::Vector<uint16_t> changed_instance_ids,
+                                        uint16_t obs_number,
                                         bool send_object = false);
 
 protected:
@@ -567,13 +568,8 @@ private:
 
 private:
     lwm2m_parameters_s          *_sn_resource;
-    M2MReportHandler            *_report_handler;
-    M2MObservationHandler       *_observation_handler; // Not owned
-    uint8_t                     *_token;
-    unsigned                    _observation_number : 16;
-    unsigned                    _token_length : 8;
-    M2MBase::Observation        _observation_level : 4;
-    bool                        _is_under_observation : 1;
+    M2MReportHandler            *_report_handler; // TODO: can be broken down to smaller classes with inheritance.
+    M2MObservationHandler       *_observation_handler; // Not owned // TODO: This can be moved to higher level , M2MObject ?
 
 friend class Test_M2MBase;
 friend class Test_M2MObject;

--- a/mbed-client/m2mbase.h
+++ b/mbed-client/m2mbase.h
@@ -87,6 +87,19 @@ public:
     }Mode;
 
     /**
+     * \brief Enum defining a resource data type.
+    */
+    typedef enum {
+        STRING,
+        INTEGER,
+        FLOAT,
+        BOOLEAN,
+        OPAQUE,
+        TIME,
+        OBJLINK
+    }DataType;
+
+    /**
      * Enum defining an operation that can be
      * supported by a given resource.
     */
@@ -127,6 +140,8 @@ public:
         char*               name; //for backwards compability
         sn_nsdl_dynamic_resource_parameters_s *dynamic_resource_params;
         BaseType            base_type;
+        M2MBase::DataType   data_type;
+        bool                multiple_instance;
         bool                free_on_delete;   /**< true if struct is dynamically allocted and it
                                                  and its members (name) are to be freed on destructor.
                                                  Note: the sn_nsdl_dynamic_resource_parameters_s has
@@ -160,7 +175,9 @@ protected:
             const String &resource_type,
 #endif
             char *path,
-            bool external_blockwise_store);
+            bool external_blockwise_store,
+            bool multiple_instance,
+            M2MBase::DataType type = M2MBase::OBJLINK);
 
     M2MBase(const lwm2m_parameters_s* s);
 
@@ -476,6 +493,13 @@ public:
      * @return Resource information.
      */
     sn_nsdl_dynamic_resource_parameters_s* get_nsdl_resource();
+
+    /**
+     * @brief Returns the resource structure.
+     * @return Resource structure.
+     */
+    M2MBase::lwm2m_parameters_s* get_lwm2m_parameters() const;
+
 
     static char* create_path(const M2MObject &parent, const char *name);
     static char* create_path(const M2MObject &parent, uint16_t object_instance);

--- a/mbed-client/m2mobjectinstance.h
+++ b/mbed-client/m2mobjectinstance.h
@@ -291,6 +291,16 @@ public:
 
 private:
 
+    /**
+     * \brief Utility function to map M2MResourceInstance ResourceType
+     * to M2MBase::DataType.
+     * \param resource_type M2MResourceInstance::ResourceType.
+     * \return M2MBase::DataType.
+     */
+    M2MBase::DataType convert_resource_type(M2MResourceInstance::ResourceType);
+
+private:
+
     M2MObject      &_parent;
 
     M2MResourceList     _resource_list; // owned

--- a/mbed-client/m2mreportobserver.h
+++ b/mbed-client/m2mreportobserver.h
@@ -33,9 +33,11 @@ class M2MReportObserver
      * \brief An observation callback to be sent to the
      * server due to a change in the observed parameter.
      * \param changed_instance_ids A list of changed object instance IDs.
+     * \param obs_number The observation number.
      * \param send_object Indicates whether the whole object will be sent or not.
      */
     virtual void observation_to_be_sent(m2m::Vector<uint16_t> changed_instance_ids,
+                                        uint16_t obs_number,
                                         bool send_object = false) = 0;
 
 };

--- a/mbed-client/m2mresource.h
+++ b/mbed-client/m2mresource.h
@@ -23,11 +23,6 @@
 class M2MObjectInstance;
 typedef Vector<M2MResourceInstance *> M2MResourceInstanceList;
 
-class M2MResourceCallback {
-public:
-    virtual void notification_update() = 0;
-};
-
 /*! \file m2mresource.h
  *  \brief M2MResource.
  *  This class is the base class for mbed Client Resources. All defined
@@ -35,7 +30,7 @@ public:
  *  instances associated with the given object.
  */
 
-class M2MResource : public M2MResourceInstance, M2MResourceCallback {
+class M2MResource : public M2MResourceInstance {
 
     friend class M2MObjectInstance;
 
@@ -48,7 +43,7 @@ private: // Constructor and destructor are private,
 
     M2MResource(M2MObjectInstance &_parent,
                  const lwm2m_parameters_s* s,
-                 M2MResourceInstance::ResourceType type);
+                 M2MBase::DataType type);
     /**
      * \brief Constructor
      * \param resource_name The resource name of the object.
@@ -65,7 +60,7 @@ private: // Constructor and destructor are private,
     M2MResource(M2MObjectInstance &_parent,
                 const String &resource_name,
                 const String &resource_type,
-                M2MResourceInstance::ResourceType type,
+                M2MBase::DataType type,
                 const uint8_t *value,
                 const uint8_t value_length,
                 char *path,
@@ -87,7 +82,7 @@ private: // Constructor and destructor are private,
     M2MResource(M2MObjectInstance &_parent,
                 const String &resource_name,
                 const String &resource_type,
-                M2MResourceInstance::ResourceType type,
+                M2MBase::DataType type,
                 bool observable,
                 char *path,
                 bool multiple_instance = false,
@@ -245,10 +240,6 @@ public:
     */
     virtual const char* object_name() const;
 
-protected:
-    virtual void notification_update();
-
-
 private:
     M2MObjectInstance &_parent;
 
@@ -257,9 +248,7 @@ private:
     uint8_t                     *_delayed_token;
     uint8_t                     _delayed_token_len;
     bool                        _delayed_response;
-#endif
-    bool                        _has_multiple_instances;
-
+#endif    
 
 friend class Test_M2MResource;
 friend class Test_M2MObjectInstance;

--- a/source/include/m2mreporthandler.h
+++ b/source/include/m2mreporthandler.h
@@ -105,6 +105,50 @@ public:
      */
     uint8_t attribute_flags();
 
+    /**
+     * \brief Sets the observation token value.
+     * \param token A pointer to the token of the resource.
+     * \param length The length of the token pointer.
+     */
+    void set_observation_token(const uint8_t *token, const uint8_t length);
+
+    /**
+     * \brief Provides the observation token of the object.
+     * \param value[OUT] A pointer to the value of the token.
+     * \param value_length[OUT] The length of the token pointer.
+     */
+    void get_observation_token(uint8_t *&token, uint32_t &token_length);
+
+    /**
+     * \brief Returns the observation number.
+     * \return The observation number of the object.
+     */
+    uint16_t observation_number() const;
+
+    /**
+     * \brief Adds the observation level for the object.
+     * \param observation_level The level of observation.
+     */
+    void add_observation_level(M2MBase::Observation obs_level);
+
+    /**
+     * \brief Removes the observation level for the object.
+     * \param observation_level The level of observation.
+     */
+    void remove_observation_level(M2MBase::Observation obs_level);
+
+    /**
+     * \brief Returns the observation level of the object.
+     * \return The observation level of the object.
+     */
+    M2MBase::Observation observation_level() const;
+
+    /**
+     * @brief Returns whether this resource is under observation or not.
+     * @return True if the resource is under observation, else false,
+     */
+    bool is_under_observation() const;
+
 protected : // from M2MTimerObserver
 
     virtual void timer_expired(M2MTimerObserver::Type type =
@@ -157,14 +201,40 @@ private:
      */
     bool check_gt_lt_params();
 
+    /**
+     * \brief Allocate (size + 1) amount of memory, copy size bytes into
+     * it and add zero termination.
+     * \param source The source string to copy, may not be NULL.
+     * \param size The size of memory to be reserved.
+    */
+    uint8_t* alloc_string_copy(const uint8_t* source, uint32_t size);
+
+    /**
+     * \brief Memory allocation required for libCoap.
+     * \param size The size of memory to be reserved.
+    */
+    void* memory_alloc(uint32_t size);
+
+    /**
+     * \brief Memory free functions required for libCoap.
+     * \param ptr The object whose memory needs to be freed.
+    */
+    void memory_free(void *ptr);
+
+
 private:
     M2MReportObserver           &_observer;
+    bool                        _is_under_observation : 1;
+    M2MBase::Observation        _observation_level : 4;
     uint8_t                     _attribute_state;
+    unsigned                    _token_length : 8;
     bool                        _notify;
     bool                        _pmin_exceeded;
     bool                        _pmax_exceeded;
+    unsigned                    _observation_number : 16;
     M2MTimer                    _pmin_timer;
     M2MTimer                    _pmax_timer;
+    uint8_t                     *_token;
     int32_t                     _pmax;
     int32_t                     _pmin;
     float                       _current_value;

--- a/source/m2mbase.cpp
+++ b/source/m2mbase.cpp
@@ -41,7 +41,9 @@ M2MBase::M2MBase(const String& resource_name,
                  const String &resource_type,
 #endif
                  char *path,
-                 bool external_blockwise_store)
+                 bool external_blockwise_store,
+                 bool multiple_instance,
+                 M2MBase::DataType type)
 :
   _sn_resource(NULL),
   _report_handler(NULL),
@@ -54,6 +56,8 @@ M2MBase::M2MBase(const String& resource_name,
     if(_sn_resource) {
         memset(_sn_resource, 0, sizeof(lwm2m_parameters_s));
         _sn_resource->free_on_delete = true;
+        _sn_resource->multiple_instance = multiple_instance;
+        _sn_resource->data_type = type;
         _sn_resource->dynamic_resource_params =
                 (sn_nsdl_dynamic_resource_parameters_s*)memory_alloc(sizeof(sn_nsdl_dynamic_resource_parameters_s));
         if(_sn_resource->dynamic_resource_params) {
@@ -787,4 +791,9 @@ size_t M2MBase::resource_name_length() const
 sn_nsdl_dynamic_resource_parameters_s* M2MBase::get_nsdl_resource()
 {
     return _sn_resource->dynamic_resource_params;
+}
+
+M2MBase::lwm2m_parameters_s* M2MBase::get_lwm2m_parameters() const
+{
+    return _sn_resource;
 }

--- a/source/m2mfirmware.cpp
+++ b/source/m2mfirmware.cpp
@@ -221,6 +221,8 @@ const static M2MBase::lwm2m_parameters firmware_package_params = {
     (char*)FIRMWARE_PACKAGE, // name
     &firmware_package_params_dynamic,
     M2MBase::Resource, // base_type
+    M2MBase::OPAQUE,
+    false,
     false // free_on_delete
 };
 
@@ -231,6 +233,8 @@ const static M2MBase::lwm2m_parameters firmware_package_uri_params = {
     (char*)FIRMWARE_PACKAGE_URI, // name
     &firmware_package_uri_params_dynamic,
     M2MBase::Resource, // base_type
+    M2MBase::STRING,
+    false,
     false // free_on_delete
 };
 
@@ -241,6 +245,8 @@ const static M2MBase::lwm2m_parameters firmware_update_params = {
     (char*)FIRMWARE_UPDATE, // name
     &firmware_update_params_dynamic,
     M2MBase::Resource, // base_type
+    M2MBase::OPAQUE,
+    false,
     false // free_on_delete
 };
 
@@ -251,6 +257,8 @@ const static M2MBase::lwm2m_parameters firmware_state_params = {
     (char*)FIRMWARE_STATE, // name
     &firmware_state_params_dynamic,
     M2MBase::Resource, // base_type
+    M2MBase::INTEGER,
+    false,
     false // free_on_delete
 };
 
@@ -261,6 +269,8 @@ const static M2MBase::lwm2m_parameters firmware_update_result_params = {
     (char*)FIRMWARE_UPDATE_RESULT, // name
     &firmware_update_result_params_dynamic,
     M2MBase::Resource, // base_type
+    M2MBase::INTEGER,
+    false,
     false // free_on_delete
 };
 

--- a/source/m2mobject.cpp
+++ b/source/m2mobject.cpp
@@ -34,7 +34,8 @@ M2MObject::M2MObject(const String &object_name, char *path, bool external_blockw
           "",
 #endif
           path,
-          external_blockwise_store)
+          external_blockwise_store,
+          false)
 {
     M2MBase::set_base_type(M2MBase::Object);
     if(M2MBase::name_id() != -1) {

--- a/source/m2mobjectinstance.cpp
+++ b/source/m2mobjectinstance.cpp
@@ -42,7 +42,8 @@ M2MObjectInstance::M2MObjectInstance(M2MObject& parent, const String &object_nam
           resource_type,
 #endif
           path,
-          external_blockwise_store),
+          external_blockwise_store,
+          false),
   _parent(parent)
 {
     M2MBase::set_base_type(M2MBase::ObjectInstance);
@@ -80,7 +81,7 @@ M2MResource* M2MObjectInstance::create_static_resource(const lwm2m_parameters_s*
         return res;
     }
     if(!resource(static_res->name)) {
-        res = new M2MResource(*this, static_res, type);
+        res = new M2MResource(*this, static_res, convert_resource_type(type));
         if(res) {
             res->add_observation_level(observation_level());
             //if (multiple_instance) {
@@ -109,7 +110,7 @@ M2MResource* M2MObjectInstance::create_static_resource(const String &resource_na
         char *path = create_path(*this, resource_name.c_str());
 
         if (path) {
-            res = new M2MResource(*this, resource_name, resource_type, type,
+            res = new M2MResource(*this, resource_name, resource_type, convert_resource_type(type),
                                   value, value_length, path,
                                   multiple_instance, external_blockwise_store);
             if(res) {
@@ -135,7 +136,7 @@ M2MResource* M2MObjectInstance::create_dynamic_resource(const lwm2m_parameters_s
         return res;
     }
     if(!resource(static_res->name)) {
-        res = new M2MResource(*this, static_res, type);
+        res = new M2MResource(*this, static_res, convert_resource_type(type));
         if(res) {
             //if (multiple_instance) { // TODO!
               //  res->set_coap_content_type(COAP_CONTENT_OMA_TLV_TYPE);
@@ -162,7 +163,7 @@ M2MResource* M2MObjectInstance::create_dynamic_resource(const String &resource_n
     if(!resource(resource_name)) {
         char *path = create_path(*this, resource_name.c_str());
         if (path) {
-            res = new M2MResource(*this, resource_name, resource_type, type,
+            res = new M2MResource(*this, resource_name, resource_type, convert_resource_type(type),
                                   observable, path,
                                   multiple_instance, external_blockwise_store);
             if(res) {
@@ -195,7 +196,7 @@ M2MResourceInstance* M2MObjectInstance::create_static_resource_instance(const St
     if(!res) {
         char *path = create_path(*this, resource_name.c_str());
         if (path) {
-            res = new M2MResource(*this, resource_name, resource_type, type,
+            res = new M2MResource(*this, resource_name, resource_type, convert_resource_type(type),
                                   value, value_length, path,
                                   true, external_blockwise_store);
             _resource_list.push_back(res);
@@ -207,9 +208,9 @@ M2MResourceInstance* M2MObjectInstance::create_static_resource_instance(const St
     if(res && res->supports_multiple_instances()&& (res->resource_instance(instance_id) == NULL)) {
         char *path = M2MBase::create_path(*res, instance_id);
         if (path) {
-            instance = new M2MResourceInstance(*res, resource_name, resource_type, type,
+            instance = new M2MResourceInstance(*res, resource_name, resource_type, convert_resource_type(type),
                                                value, value_length,
-                                               path, external_blockwise_store);
+                                               path, external_blockwise_store,true);
             if(instance) {
                 instance->set_operation(M2MBase::GET_ALLOWED);
                 instance->set_instance_id(instance_id);
@@ -236,7 +237,7 @@ M2MResourceInstance* M2MObjectInstance::create_dynamic_resource_instance(const S
     if(!res) {
         char *path = create_path(*this, resource_name.c_str());
         if (path) {
-            res = new M2MResource(*this, resource_name, resource_type, type,
+            res = new M2MResource(*this, resource_name, resource_type, convert_resource_type(type),
                                   false, path, M2MBase::instance_id(), true);
             _resource_list.push_back(res);
             res->set_register_uri(false);
@@ -246,8 +247,8 @@ M2MResourceInstance* M2MObjectInstance::create_dynamic_resource_instance(const S
     if (res && res->supports_multiple_instances() && (res->resource_instance(instance_id) == NULL)) {
         char *path = create_path(*res, instance_id);
         if (path) {
-            instance = new M2MResourceInstance(*res, resource_name, resource_type, type,
-                                               path, external_blockwise_store);
+            instance = new M2MResourceInstance(*res, resource_name, resource_type, convert_resource_type(type),
+                                               path, external_blockwise_store,true);
             if(instance) {
                 instance->set_operation(M2MBase::GET_ALLOWED);
                 instance->set_observable(observable);
@@ -717,4 +718,33 @@ void M2MObjectInstance::notification_update(M2MBase::Observation observation_lev
         }
 
     }
+}
+
+M2MBase::DataType M2MObjectInstance::convert_resource_type(M2MResourceInstance::ResourceType type)
+{
+    M2MBase::DataType data_type = M2MBase::OBJLINK;
+    switch(type) {
+        case M2MResourceInstance::STRING:
+            data_type = M2MBase::STRING;
+            break;
+        case M2MResourceInstance::INTEGER:
+            data_type = M2MBase::INTEGER;
+            break;
+        case M2MResourceInstance::FLOAT:
+            data_type = M2MBase::FLOAT;
+            break;
+        case M2MResourceInstance::OPAQUE:
+            data_type = M2MBase::OPAQUE;
+            break;
+        case M2MResourceInstance::BOOLEAN:
+            data_type = M2MBase::BOOLEAN;
+            break;
+        case M2MResourceInstance::TIME:
+            data_type = M2MBase::TIME;
+            break;
+        case M2MResourceInstance::OBJLINK:
+            data_type = M2MBase::OBJLINK;
+            break;
+    }
+    return data_type;
 }

--- a/source/m2mreporthandler.cpp
+++ b/source/m2mreporthandler.cpp
@@ -30,12 +30,17 @@
 
 M2MReportHandler::M2MReportHandler(M2MReportObserver &observer)
 : _observer(observer),
+  _is_under_observation(false),
+  _observation_level(M2MBase::None),
   _attribute_state(0),
+  _token_length(0),
   _notify(false),
   _pmin_exceeded(false),
   _pmax_exceeded(false),
+  _observation_number(0),
   _pmin_timer(*this),
   _pmax_timer(*this),
+  _token(NULL),
   _pmax(-1.0f),
   _pmin(1.0f),
   _current_value(0.0f),
@@ -52,6 +57,7 @@ M2MReportHandler::M2MReportHandler(M2MReportObserver &observer)
 M2MReportHandler::~M2MReportHandler()
 {
     tr_debug("M2MReportHandler::~M2MReportHandler()");
+    free(_token);
 }
 
 void M2MReportHandler::set_under_observation(bool observed)
@@ -302,14 +308,16 @@ void M2MReportHandler::report()
         _pmin_exceeded = false;
         _pmax_exceeded = false;
         _notify = false;
-        _observer.observation_to_be_sent(_changed_instance_ids);
+        _observation_number++;
+        _observer.observation_to_be_sent(_changed_instance_ids, observation_number());
         _changed_instance_ids.clear();
         _pmax_timer.stop_timer();
     }
     else {
         if (_pmax_exceeded) {
             tr_debug("M2MReportHandler::report()- send with PMAX");
-            _observer.observation_to_be_sent(_changed_instance_ids, true);
+            _observation_number++;
+            _observer.observation_to_be_sent(_changed_instance_ids, observation_number(),true);
             _changed_instance_ids.clear();
         }
         else {
@@ -470,4 +478,80 @@ bool M2MReportHandler::check_gt_lt_params()
 uint8_t M2MReportHandler::attribute_flags()
 {
     return _attribute_state;
+}
+
+void M2MReportHandler::set_observation_token(const uint8_t *token, const uint8_t length)
+{
+     free(_token);
+     _token = NULL;
+     _token_length = 0;
+
+    if( token != NULL && length > 0 ) {
+        _token = alloc_string_copy((uint8_t *)token, length);
+        if(_token) {
+            _token_length = length;
+        }
+    }
+}
+
+void M2MReportHandler::get_observation_token(uint8_t *&token, uint32_t &token_length)
+{
+    token_length = 0;
+    free(token);
+    if (_token) {
+        token = alloc_string_copy((uint8_t *)_token, _token_length);
+        if(token) {
+            token_length = _token_length;
+        }
+    }
+}
+
+uint16_t M2MReportHandler::observation_number() const
+{
+    return _observation_number;
+}
+
+void M2MReportHandler::add_observation_level(M2MBase::Observation obs_level)
+{
+    _observation_level = (M2MBase::Observation)(_observation_level | obs_level);
+}
+
+void M2MReportHandler::remove_observation_level(M2MBase::Observation obs_level)
+{
+    _observation_level = (M2MBase::Observation)(_observation_level & ~obs_level);
+}
+
+M2MBase::Observation M2MReportHandler::observation_level() const
+{
+    return _observation_level;
+}
+
+bool M2MReportHandler::is_under_observation() const
+{
+    return _is_under_observation;
+}
+
+uint8_t* M2MReportHandler::alloc_string_copy(const uint8_t* source, uint32_t size)
+{
+    assert(source != NULL);
+
+    uint8_t* result = (uint8_t*)memory_alloc(size + 1);
+    if (result) {
+        memcpy(result, source, size);
+        result[size] = '\0';
+    }
+    return result;
+}
+
+void *M2MReportHandler::memory_alloc(uint32_t size)
+{
+    if(size)
+        return malloc(size);
+    else
+        return 0;
+}
+
+void M2MReportHandler::memory_free(void *ptr)
+{
+    free(ptr);
 }


### PR DESCRIPTION
This commit includes
 - Moving observation token, observation number and observation flag  from M2MBase to M2MReportHandler