### PR TITLE
Remvoving _value and _value_length from M2MResourceInstance

### DIFF
--- a/mbed-client/m2mbase.h
+++ b/mbed-client/m2mbase.h
@@ -492,7 +492,7 @@ public:
      * @brief Returns the resource information.
      * @return Resource information.
      */
-    sn_nsdl_dynamic_resource_parameters_s* get_nsdl_resource();
+    sn_nsdl_dynamic_resource_parameters_s* get_nsdl_resource() const;
 
     /**
      * @brief Returns the resource structure.

--- a/mbed-client/m2mresourceinstance.h
+++ b/mbed-client/m2mresourceinstance.h
@@ -316,9 +316,6 @@ private:
     // pointer to itself. If this inheritance was broken, we could save some memory.
     M2MResource &_parent_resource;
 
-    uint8_t                                 *_value;        //TODO: remove it from here and use it directly from sn_nsdl_static_resource_parameters_
-                                                            // but move resource* and resource Len to dynamic resource structure.
-    uint32_t                                _value_length;
 #ifndef DISABLE_BLOCK_MESSAGE
     M2MBlockMessage                         *_block_message_data;
 #endif

--- a/source/m2mbase.cpp
+++ b/source/m2mbase.cpp
@@ -764,7 +764,7 @@ void M2MBase::free_resources()
                 const_cast<sn_nsdl_static_resource_parameters_s *>(_sn_resource->dynamic_resource_params->static_resource_parameters);
 
         free(params->path);
-        free(params->resource);
+//        free(params->resource);
 #ifndef DISABLE_RESOURCE_TYPE
         free(params->resource_type_ptr);
 #endif
@@ -772,6 +772,9 @@ void M2MBase::free_resources()
         free(params->interface_description_ptr);
 #endif
         free(params);
+    }
+    if (_sn_resource->dynamic_resource_params->resource) {
+        free(_sn_resource->dynamic_resource_params->resource);
     }
     if (_sn_resource->dynamic_resource_params->free_on_delete) {
         free(_sn_resource->dynamic_resource_params);
@@ -788,7 +791,7 @@ size_t M2MBase::resource_name_length() const
     return strlen(_sn_resource->name);
 }
 
-sn_nsdl_dynamic_resource_parameters_s* M2MBase::get_nsdl_resource()
+sn_nsdl_dynamic_resource_parameters_s* M2MBase::get_nsdl_resource() const
 {
     return _sn_resource->dynamic_resource_params;
 }

--- a/source/m2mfirmware.cpp
+++ b/source/m2mfirmware.cpp
@@ -76,8 +76,8 @@ static sn_nsdl_static_resource_parameters_s firmware_package_params_static = {
     (char*)"",                     // interface_description_ptr
 #endif	
     (char*)PACKAGE_PATH,    // path
-    (uint8_t*)"",           // resource
-    0,                      // resourcelen
+//    (uint8_t*)"",           // resource
+//    0,                      // resourcelen
     false,                  // external_memory_block
     SN_GRS_DYNAMIC,         // mode
     false                   // free_on_delete
@@ -94,8 +94,8 @@ static sn_nsdl_static_resource_parameters_s firmware_package_uri_params_static =
     (char*)"",                     // interface_description_ptr
 #endif
     (char*)PACKAGE_URI_PATH, // path
-    (uint8_t*)"",           // resource
-    0,                      // resourcelen
+//    (uint8_t*)"",           // resource
+//    0,                      // resourcelen
     false,                  // external_memory_block
     SN_GRS_DYNAMIC,         // mode
     false                   // free_on_delete
@@ -112,8 +112,8 @@ static sn_nsdl_static_resource_parameters_s firmware_update_params_static = {
     (char*)"",                  // interface_description_ptr
 #endif
     (char*)UPDATE_PATH,     // path
-    (uint8_t*)"",           // resource
-    0,                      // resourcelen
+//    (uint8_t*)"",           // resource
+//    0,                      // resourcelen
     false,                  // external_memory_block
     SN_GRS_DYNAMIC,         // mode
     false                   // free_on_delete
@@ -130,8 +130,8 @@ static sn_nsdl_static_resource_parameters_s firmware_state_params_static = {
     (char*)"",                  // interface_description_ptr
 #endif
     (char*)STATE_URI_PATH,   // path
-    (uint8_t*)"0",          // resource
-    1,                      // resourcelen
+//    (uint8_t*)"0",          // resource
+//    1,                      // resourcelen
     false,                  // external_memory_block
     SN_GRS_DYNAMIC,         // mode
     false                   // free_on_delete
@@ -148,8 +148,8 @@ static sn_nsdl_static_resource_parameters_s firmware_update_result_params_static
     (char*)"",                     // interface_description_ptr
 #endif
     (char*)UPDATE_RESULT_PATH, // path
-    (uint8_t*)"0",          // resource
-    1,                      // resourcelen
+//    (uint8_t*)"0",          // resource
+//    1,                      // resourcelen
     false,                  // external_memory_block
     SN_GRS_DYNAMIC,         // mode
     false                   // free_on_delete
@@ -158,7 +158,9 @@ static sn_nsdl_static_resource_parameters_s firmware_update_result_params_static
 static sn_nsdl_dynamic_resource_parameters_s firmware_package_params_dynamic = {
     __nsdl_c_callback,
     &firmware_package_params_static,
+    NULL,
     {NULL, NULL},                     // link
+    0,
     COAP_CONTENT_OMA_PLAIN_TEXT_TYPE, // coap_content_type
     M2MBase::PUT_ALLOWED,   // access
     0,                      // registered
@@ -170,7 +172,9 @@ static sn_nsdl_dynamic_resource_parameters_s firmware_package_params_dynamic = {
 static sn_nsdl_dynamic_resource_parameters_s firmware_package_uri_params_dynamic = {
     __nsdl_c_callback,
     &firmware_package_uri_params_static,
+    NULL,
     {NULL, NULL},                     // link
+    0,
     COAP_CONTENT_OMA_PLAIN_TEXT_TYPE, // coap_content_type
     M2MBase::PUT_ALLOWED,   // access
     0,                      // registered
@@ -182,7 +186,9 @@ static sn_nsdl_dynamic_resource_parameters_s firmware_package_uri_params_dynamic
 static sn_nsdl_dynamic_resource_parameters_s firmware_update_params_dynamic = {
     __nsdl_c_callback,
     &firmware_update_params_static,
+    NULL,
     {NULL, NULL},                     // link
+    0,
     COAP_CONTENT_OMA_PLAIN_TEXT_TYPE, // coap_content_type
     M2MBase::NOT_ALLOWED,   // access
     0,                      // registered
@@ -194,7 +200,9 @@ static sn_nsdl_dynamic_resource_parameters_s firmware_update_params_dynamic = {
 static sn_nsdl_dynamic_resource_parameters_s firmware_state_params_dynamic = {
     __nsdl_c_callback,
     &firmware_state_params_static,
+    NULL,
     {NULL, NULL},                     // link
+    0,
     COAP_CONTENT_OMA_PLAIN_TEXT_TYPE, // coap_content_type
     M2MBase::GET_ALLOWED,   // access
     0,                      // registered
@@ -206,7 +214,9 @@ static sn_nsdl_dynamic_resource_parameters_s firmware_state_params_dynamic = {
 static sn_nsdl_dynamic_resource_parameters_s firmware_update_result_params_dynamic = {
     __nsdl_c_callback,
     &firmware_update_result_params_static,
+    NULL,
     {NULL, NULL},                     // link
+    0,
     COAP_CONTENT_OMA_PLAIN_TEXT_TYPE, // coap_content_type
     M2MBase::GET_ALLOWED,   // access
     0,                      // registered


### PR DESCRIPTION
This commit includes
 - Removing _value and _value_length from M2MResourceInstance and use the parameter from
   mbed-client-c dynamic struct.