### PR TITLE
Reconnection logic re-work.

### DIFF
--- a/source/include/m2minterfaceimpl.h
+++ b/source/include/m2minterfaceimpl.h
@@ -388,6 +388,12 @@ private: // state machine state functions
      */
     static void process_address(const String& server_address, String& ip_address, uint16_t& port);
 
+    enum ReconnectionState{
+        None,
+        WithUpdate,
+        FullRegistration
+    };
+
 private:
 
     EventData                   *_event_data;
@@ -412,6 +418,7 @@ private:
     uint8_t                     _current_state;
     uint8_t                     _retry_count;
     BindingMode                 _binding_mode;
+    ReconnectionState           _reconnection_state;
     M2MInterfaceObserver        &_observer;
     M2MConnectionSecurity       *_security_connection; // Doesn't own
     M2MConnectionHandler        _connection_handler;

--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -107,17 +107,21 @@ public:
     bool create_bootstrap_resource(sn_nsdl_addr_s *address, const String &bootstrap_endpoint_name);
 
     /**
-     * @brief Sends the register message to the server.
+     * @brief Sets the register message to the server.
      * @param address M2MServer address.
      * @param address_length M2MServer address length.
      * @param port M2MServer port.
      * @param address_type IP Address type.
+    */
+    void set_server_address(uint8_t* address,
+                            uint8_t address_length,
+                            const uint16_t port,
+                            sn_nsdl_addr_type_e address_type);
+    /**
+     * @brief Sends the register message to the server.
      * @return  true if register sent successfully else false.
     */
-    bool send_register_message(uint8_t* address,
-                               uint8_t address_length,
-                               const uint16_t port,
-                               sn_nsdl_addr_type_e address_type);
+    bool send_register_message();
 
     /**
      * @brief Sends the update registration message to the server.

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -839,7 +839,18 @@ void M2MInterfaceImpl::state_update_registration(EventData *data)
         }
         lifetime = event->_lifetime;
     }
-    _nsdl_interface.send_update_registration(lifetime);
+
+    bool success = _nsdl_interface.send_update_registration(lifetime);
+    if(!success) {
+        if(_reconnection_state == M2MInterfaceImpl::WithUpdate) {
+            _reconnection_state = M2MInterfaceImpl::FullRegistration;
+            if(!_nsdl_interface.send_register_message()) {
+                tr_error("M2MInterfaceImpl::state_update_registration : M2MInterface::InvalidParameters");
+                internal_event(STATE_IDLE);
+                _observer.error(M2MInterface::InvalidParameters);
+            }
+        }
+    }
 }
 
 void M2MInterfaceImpl::state_unregister( EventData */*data*/)

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -234,20 +234,23 @@ bool M2MNsdlInterface::create_bootstrap_resource(sn_nsdl_addr_s *address, const 
 #endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
 }
 
-bool M2MNsdlInterface::send_register_message(uint8_t* address,
-                                             uint8_t address_length,
-                                             const uint16_t port,
-                                             sn_nsdl_addr_type_e address_type)
+void M2MNsdlInterface::set_server_address(uint8_t* address,
+                                          uint8_t address_length,
+                                          const uint16_t port,
+                                          sn_nsdl_addr_type_e address_type)
+{
+    tr_debug("M2MNsdlInterface::set_server_address()");
+    set_NSP_address(_nsdl_handle, address, address_length, port, address_type);
+}
+
+bool M2MNsdlInterface::send_register_message()
 {
     tr_debug("M2MNsdlInterface::send_register_message()");
     _nsdl_exceution_timer->stop_timer();
     _nsdl_exceution_timer->start_timer(ONE_SECOND_TIMER * 1000,
                                        M2MTimerObserver::NsdlExecution,
                                        false);
-    bool success = false;
-    if(set_NSP_address(_nsdl_handle, address, address_length, port, address_type) == 0) {
-        success = sn_nsdl_register_endpoint(_nsdl_handle,_endpoint) != 0;
-    }
+    bool success = sn_nsdl_register_endpoint(_nsdl_handle,_endpoint) != 0;
     return success;
 }
 

--- a/test/mbedclient/utest/m2minterfaceimpl/test_m2minterfaceimpl.cpp
+++ b/test/mbedclient/utest/m2minterfaceimpl/test_m2minterfaceimpl.cpp
@@ -676,6 +676,13 @@ void Test_M2MInterfaceImpl::test_address_ready()
     impl->address_ready(*address,server_type,server_port);
     CHECK(impl->_current_state == M2MInterfaceImpl::STATE_REGISTER_ADDRESS_RESOLVED);
 
+    impl->_reconnection_state = M2MInterfaceImpl::WithUpdate;
+    impl->address_ready(*address,server_type,server_port);
+    CHECK(impl->_current_state == M2MInterfaceImpl::STATE_UPDATE_REGISTRATION);
+
+
+    impl->_reconnection_state = M2MInterfaceImpl::None;
+
     address->_stack = M2MInterface::LwIP_IPv6;
     m2mnsdlinterface_stub::bool_value = false;
 

--- a/test/mbedclient/utest/m2minterfaceimpl/test_m2minterfaceimpl.cpp
+++ b/test/mbedclient/utest/m2minterfaceimpl/test_m2minterfaceimpl.cpp
@@ -366,12 +366,22 @@ void Test_M2MInterfaceImpl::test_update_registration()
     CHECK(impl->_current_state == M2MInterfaceImpl::STATE_UPDATE_REGISTRATION);
 
     impl->_current_state = M2MInterfaceImpl::STATE_REGISTERED;
-    m2mnsdlinterface_stub::bool_value = false;
+    m2mnsdlinterface_stub::bool_value = true;
     impl->update_registration(NULL,120);
 
     CHECK(impl->_current_state == M2MInterfaceImpl::STATE_UPDATE_REGISTRATION);
 
     impl->_current_state = M2MInterfaceImpl::STATE_IDLE;
+
+    impl->_current_state = M2MInterfaceImpl::STATE_REGISTERED;
+
+    m2mnsdlinterface_stub::bool_value = false;
+    impl->update_registration(NULL,120);
+
+    CHECK(impl->_current_state == M2MInterfaceImpl::STATE_IDLE);
+    CHECK(observer->error_occured == true);
+
+    m2mnsdlinterface_stub::bool_value = true;
     impl->update_registration(NULL,120);
 
     CHECK(impl->_current_state == M2MInterfaceImpl::STATE_IDLE);
@@ -397,14 +407,14 @@ void Test_M2MInterfaceImpl::test_update_registration()
     M2MObjectList list;
     list.push_back(object);
     impl->_current_state = M2MInterfaceImpl::STATE_REGISTERED;
-    m2mnsdlinterface_stub::bool_value = false;
+    m2mnsdlinterface_stub::bool_value = true;
     impl->update_registration(NULL, list);
 
     CHECK(impl->_current_state == M2MInterfaceImpl::STATE_UPDATE_REGISTRATION);
     list.clear();
 
     impl->_current_state = M2MInterfaceImpl::STATE_REGISTERED;
-    m2mnsdlinterface_stub::bool_value = false;
+    m2mnsdlinterface_stub::bool_value = true;
     impl->update_registration(NULL, list);
 
     CHECK(impl->_current_state == M2MInterfaceImpl::STATE_UPDATE_REGISTRATION);

--- a/test/mbedclient/utest/m2mnsdlinterface/m2mnsdlinterfacetest.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/m2mnsdlinterfacetest.cpp
@@ -57,6 +57,11 @@ TEST(M2MNsdlInterface, send_update_registration)
     m2m_nsdl_interface->test_send_update_registration();
 }
 
+TEST(M2MNsdlInterface, set_server_address)
+{
+    m2m_nsdl_interface->test_set_server_address();
+}
+
 TEST(M2MNsdlInterface, send_register_message)
 {
     m2m_nsdl_interface->test_send_register_message();

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
@@ -268,14 +268,22 @@ void Test_M2MNsdlInterface::test_create_bootstrap_resource()
     CHECK(nsdl->create_bootstrap_resource(NULL, "") == false);
 }
 
+void Test_M2MNsdlInterface::test_set_server_address()
+{
+    // to cover the test coverage
+    nsdl->set_server_address(NULL,4,100,SN_NSDL_ADDRESS_TYPE_IPV6);
+}
+
 void Test_M2MNsdlInterface::test_send_register_message()
 {
     common_stub::uint_value = 12;
     common_stub::int_value = 0;
-    CHECK(nsdl->send_register_message(NULL,4,100,SN_NSDL_ADDRESS_TYPE_IPV6) == true);
+    nsdl->set_server_address(NULL,4,100,SN_NSDL_ADDRESS_TYPE_IPV6);
+    CHECK(nsdl->send_register_message() == true);
 
     common_stub::uint_value = 0;
-    CHECK(nsdl->send_register_message(NULL,4,100,SN_NSDL_ADDRESS_TYPE_IPV6) == false);
+    nsdl->set_server_address(NULL,4,100,SN_NSDL_ADDRESS_TYPE_IPV6);
+    CHECK(nsdl->send_register_message() == false);
 }
 
 void Test_M2MNsdlInterface::test_send_update_registration()

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
@@ -38,6 +38,8 @@ public:
 
     void test_create_bootstrap_resource();
 
+    void test_set_server_address();
+
     void test_send_register_message();
 
     void test_send_update_registration();

--- a/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
@@ -73,10 +73,14 @@ bool M2MNsdlInterface::create_bootstrap_resource(sn_nsdl_addr_s *, const String&
     return m2mnsdlinterface_stub::bool_value;
 }
 
-bool M2MNsdlInterface::send_register_message(uint8_t*,
+void M2MNsdlInterface::set_server_address(uint8_t*,
                                              uint8_t,
                                              const uint16_t,
                                              sn_nsdl_addr_type_e)
+{
+}
+
+bool M2MNsdlInterface::send_register_message()
 {
     return m2mnsdlinterface_stub::bool_value;
 }


### PR DESCRIPTION
This commit includes
 - Changing the logic that on reconnection, client will do registration update instead of full registration.
In case, the registration update fails, client will fall back to full registration.
 - Also, the application can now try to trigger the registration update , if it doesnt want to do the full registration.
  This call may however fail if the client is not registered earlier in the mDS. The reconnection logic can kick in and
  restore the state here.
 - Updated unit tests as well.