### PR TITLE
Add API to M2MSecurity whether to verify cert expiration

### DIFF
--- a/mbed-client/m2msecurity.h
+++ b/mbed-client/m2msecurity.h
@@ -208,6 +208,17 @@ public:
      */
     ServerType server_type() const;
 
+    /**
+     * \brief Enable checking of certificate expiration based on device object when using this security object
+     */
+    void set_verify_cert_expiration(bool verify);
+
+    /**
+     * \brief Returns whether certificate expiration should be checked when using this security object
+     * \return True when certificate expiration should be checked, false otherwise.
+     */
+    bool verify_cert_expiration() const;
+
 private:
 
     M2MResource* get_resource(SecurityResource resource) const;
@@ -217,6 +228,7 @@ private:
 
     M2MObjectInstance*    _server_instance;
     ServerType            _server_type;
+    bool                  _verify_cert_expiration;
 
     friend class Test_M2MSecurity;
     friend class Test_M2MInterfaceImpl;

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -1691,6 +1691,9 @@ bool M2MNsdlInterface::validate_security_object()
             return false;
         }
     }
+    else {
+        tr_error("No security object to validate!");
+    }
     return false;
 #else
     return false;

--- a/source/m2msecurity.cpp
+++ b/source/m2msecurity.cpp
@@ -30,7 +30,8 @@
 M2MSecurity::M2MSecurity(ServerType ser_type)
 : M2MObject(M2M_SECURITY_ID, stringdup(M2M_SECURITY_ID)),
  _server_instance(NULL),
- _server_type(ser_type)
+ _server_type(ser_type),
+ _verify_cert_expiration(false)
 {
      _server_instance  = M2MObject::create_object_instance();
 
@@ -369,4 +370,14 @@ void M2MSecurity::clear_resources()
             res->clear_value();
         }
     }
+}
+
+void M2MSecurity::set_verify_cert_expiration(bool verify)
+{
+    _verify_cert_expiration = verify;
+}
+
+bool M2MSecurity::verify_cert_expiration() const
+{
+    return _verify_cert_expiration;
 }


### PR DESCRIPTION
Added new APIs set_verify_cert_expiration() and verify_cert_expiration()
for passing info to security impl whether to verify certificate expiration
based on time provided by device object

Added also one trace print if during bootstrap no security object is received