### PR TITLE
Minor serializer cleanup

### DIFF
--- a/source/include/m2mtlvdeserializer.h
+++ b/source/include/m2mtlvdeserializer.h
@@ -49,7 +49,7 @@ public :
      * @param tlv Binary to be checked as LWM2M object instance
      * @return <code>true</code> or <code>false</code>.
      */
-    static bool is_object_instance(uint8_t *tlv);
+    static bool is_object_instance(const uint8_t *tlv);
 
     
     /**
@@ -59,7 +59,7 @@ public :
      * @param tlv Binary to be checked as LWM2M resource.
      * @return <code>true</code> or <code>false</code>.
      */
-    static bool is_resource(uint8_t *tlv);
+    static bool is_resource(const uint8_t *tlv);
 
     /**
      * This method checks whether the given binary encodes a multiple resource
@@ -68,7 +68,7 @@ public :
      * @param tlv Binary to be checked as LWM2M multiple resource.
      * @return <code>true</code> or <code>false</code>.
      */
-    static bool is_multiple_resource(uint8_t *tlv);
+    static bool is_multiple_resource(const uint8_t *tlv);
     
     /**
      * This method checks whether the given binary encodes a resource instance
@@ -77,13 +77,13 @@ public :
      * @param tlv Binary to be checked as LWM2M resource instance.
      * @return <code>true</code> or <code>false</code>.
      */
-    static bool is_resource_instance(uint8_t *tlv);
+    static bool is_resource_instance(const uint8_t *tlv);
 
     /**
      * Deserialises the given binary that must encode object instances. Binary
      * array can be checked before invoking this method with 
      */
-    static M2MTLVDeserializer::Error deserialise_object_instances(uint8_t* tlv,
+    static M2MTLVDeserializer::Error deserialise_object_instances(const uint8_t* tlv,
                                                            uint32_t tlv_size,
                                                            M2MObject &object,
                                                            M2MTLVDeserializer::Operation operation);
@@ -92,7 +92,7 @@ public :
      * Deserialises the given binary that must encode resources. Binary array 
      * can be checked before invoking this method.
      */
-    static M2MTLVDeserializer::Error deserialize_resources(uint8_t *tlv,
+    static M2MTLVDeserializer::Error deserialize_resources(const uint8_t *tlv,
                                                     uint32_t tlv_size,
                                                     M2MObjectInstance &object_instance,
                                                     M2MTLVDeserializer::Operation operation);
@@ -101,7 +101,7 @@ public :
      * Deserialises the given binary that must encode resource instances. Binary array
      * can be checked before invoking this method.
      */
-    static M2MTLVDeserializer::Error deserialize_resource_instances(uint8_t *tlv,
+    static M2MTLVDeserializer::Error deserialize_resource_instances(const uint8_t *tlv,
                                                              uint32_t tlv_size,
                                                              M2MResource &resource,
                                                              M2MTLVDeserializer::Operation operation);
@@ -110,25 +110,25 @@ public :
      * @param tlv Binary to be checked
      * @return Object instance id or resource id.
      */
-    static uint16_t instance_id(uint8_t *tlv);
+    static uint16_t instance_id(const uint8_t *tlv);
     
 private:
 
-    static M2MTLVDeserializer::Error deserialize_object_instances(uint8_t *tlv,
+    static M2MTLVDeserializer::Error deserialize_object_instances(const uint8_t *tlv,
                                                            uint32_t tlv_size,
                                                            uint32_t offset,
                                                            M2MObject &object,
                                                            M2MTLVDeserializer::Operation operation,
                                                            bool update_value);
     
-    static M2MTLVDeserializer::Error deserialize_resources(uint8_t *tlv,
+    static M2MTLVDeserializer::Error deserialize_resources(const uint8_t *tlv,
                                                     uint32_t tlv_size,
                                                     uint32_t offset,
                                                     M2MObjectInstance &object_instance,
                                                     M2MTLVDeserializer::Operation operation,
                                                     bool update_value);
 
-    static M2MTLVDeserializer::Error deserialize_resource_instances(uint8_t *tlv,
+    static M2MTLVDeserializer::Error deserialize_resource_instances(const uint8_t *tlv,
                                                              uint32_t tlv_size,
                                                              uint32_t offset,
                                                              M2MResource &resource,
@@ -136,26 +136,26 @@ private:
                                                              M2MTLVDeserializer::Operation operation,
                                                              bool update_value);
 
-    static M2MTLVDeserializer::Error deserialize_resource_instances(uint8_t *tlv,
+    static M2MTLVDeserializer::Error deserialize_resource_instances(const uint8_t *tlv,
                                                              uint32_t tlv_size,
                                                              uint32_t offset,
                                                              M2MResource &resource,
                                                              M2MTLVDeserializer::Operation operation,
                                                              bool update_value);
 
-    static bool is_object_instance(uint8_t *tlv, uint32_t offset);
+    static bool is_object_instance(const uint8_t *tlv, uint32_t offset);
     
-    static bool is_resource(uint8_t *tlv, uint32_t offset);
+    static bool is_resource(const uint8_t *tlv, uint32_t offset);
     
-    static bool is_multiple_resource(uint8_t *tlv, uint32_t offset);
+    static bool is_multiple_resource(const uint8_t *tlv, uint32_t offset);
     
-    static bool is_resource_instance(uint8_t *tlv, uint32_t offset);
+    static bool is_resource_instance(const uint8_t *tlv, uint32_t offset);
 };
 
 class TypeIdLength {
 
 public:
-    TypeIdLength(uint8_t *tlv, uint32_t offset);
+    TypeIdLength(const uint8_t *tlv, uint32_t offset);
 
     void deserialize();
 
@@ -163,7 +163,7 @@ public:
 
     void deserialiseLength (uint32_t lengthType);
 
-    uint8_t     *_tlv;
+    const uint8_t     *_tlv;
     uint32_t    _offset;
     uint32_t    _type;
     uint16_t    _id;

--- a/source/include/m2mtlvdeserializer.h
+++ b/source/include/m2mtlvdeserializer.h
@@ -144,11 +144,11 @@ private:
                                                              bool update_value);
 
     static bool is_object_instance(const uint8_t *tlv, uint32_t offset);
-    
+
     static bool is_resource(const uint8_t *tlv, uint32_t offset);
-    
+
     static bool is_multiple_resource(const uint8_t *tlv, uint32_t offset);
-    
+
     static bool is_resource_instance(const uint8_t *tlv, uint32_t offset);
 };
 
@@ -159,9 +159,9 @@ public:
 
     void deserialize();
 
-    void deserialiseID (uint32_t idLength);
+    void deserialiseID(uint32_t idLength);
 
-    void deserialiseLength (uint32_t lengthType);
+    void deserialiseLength(uint32_t lengthType);
 
     const uint8_t     *_tlv;
     uint32_t    _offset;

--- a/source/include/m2mtlvserializer.h
+++ b/source/include/m2mtlvserializer.h
@@ -50,7 +50,7 @@ public:
      * @return Object instances encoded binary as OMA-TLV 
      * @see #serializeObjectInstances(List) 
      */
-    static uint8_t* serialize(M2MObjectInstanceList object_instance_list, uint32_t &size);
+    static uint8_t* serialize(const M2MObjectInstanceList &object_instance_list, uint32_t &size);
 
     /**
      * Serialises given resources with no information about the parent object
@@ -70,29 +70,29 @@ public:
      * @return Resources encoded binary as OMA-TLV
      * @see #serializeResources(List)
      */
-    static uint8_t* serialize(M2MResourceList resource_list, uint32_t &size);
+    static uint8_t* serialize(const M2MResourceList &resource_list, uint32_t &size);
 
-    static uint8_t* serialize(M2MResource *resource, uint32_t &size);
+    static uint8_t* serialize(const M2MResource *resource, uint32_t &size);
 
 private :
 
-    static uint8_t* serialize_object_instances(M2MObjectInstanceList object_instance_list, uint32_t &size);
+    static uint8_t* serialize_object_instances(const M2MObjectInstanceList &object_instance_list, uint32_t &size);
 
-    static uint8_t* serialize_resources(M2MResourceList resource_list, uint32_t &size, bool &valid);
+    static uint8_t* serialize_resources(const M2MResourceList &resource_list, uint32_t &size, bool &valid);
 
-    static bool serialize(uint16_t id, M2MObjectInstance *object_instance, uint8_t *&data, uint32_t &size);
+    static bool serialize(uint16_t id, const M2MObjectInstance *object_instance, uint8_t *&data, uint32_t &size);
     
-    static bool serialize (M2MResource *resource, uint8_t *&data, uint32_t &size);
+    static bool serialize(const M2MResource *resource, uint8_t *&data, uint32_t &size);
 
-    static bool serialize_resource(M2MResource *resource, uint8_t *&data, uint32_t &size);
+    static bool serialize_resource(const M2MResource *resource, uint8_t *&data, uint32_t &size);
 
-    static bool serialize_multiple_resource(M2MResource *resource, uint8_t *&data, uint32_t &size);
+    static bool serialize_multiple_resource(const M2MResource *resource, uint8_t *&data, uint32_t &size);
 
-    static bool serialize_resource_instance(uint16_t id, M2MResourceInstance *resource, uint8_t *&data, uint32_t &size);
+    static bool serialize_resource_instance(uint16_t id, const M2MResourceInstance *resource, uint8_t *&data, uint32_t &size);
     
     static bool serialize_TILV (uint8_t type, uint16_t id, uint8_t *value, uint32_t value_length, uint8_t *&data, uint32_t &size);
 
-    static void serialize_id(uint16_t id, uint32_t &size, uint8_t* id_ptr);
+    static void serialize_id(uint16_t id, uint32_t &size, uint8_t *id_ptr);
 
-    static void serialize_length(uint32_t length, uint32_t &size, uint8_t* length_ptr);
+    static void serialize_length(uint32_t length, uint32_t &size, uint8_t *length_ptr);
 };

--- a/source/m2mtlvdeserializer.cpp
+++ b/source/m2mtlvdeserializer.cpp
@@ -122,7 +122,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_object_instances(const
     til.deserialize();
     offset = til._offset;
 
-    M2MObjectInstanceList list = object.instances();
+    const M2MObjectInstanceList &list = object.instances();
     M2MObjectInstanceList::const_iterator it;
     it = list.begin();
 
@@ -154,7 +154,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(const uint8_
     til.deserialize();
     offset = til._offset;
 
-    M2MResourceList list = object_instance.resources();
+    const M2MResourceList &list = object_instance.resources();
     M2MResourceList::const_iterator it;
     it = list.begin();
 
@@ -226,7 +226,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(con
     offset = til._offset;
 
     if (TYPE_MULTIPLE_RESOURCE == til._type || TYPE_RESOURCE_INSTANCE == til._type) {
-        M2MResourceInstanceList list = resource.resource_instances();
+        const M2MResourceInstanceList &list = resource.resource_instances();
         M2MResourceInstanceList::const_iterator it;
         it = list.begin();
         bool found = false;
@@ -286,7 +286,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(con
     offset = til._offset;
 
     if (TYPE_RESOURCE_INSTANCE == til._type) {
-        M2MResourceInstanceList list = resource.resource_instances();
+        const M2MResourceInstanceList &list = resource.resource_instances();
         M2MResourceInstanceList::const_iterator it;
         it = list.begin();
         bool found = false;

--- a/source/m2mtlvdeserializer.cpp
+++ b/source/m2mtlvdeserializer.cpp
@@ -93,11 +93,11 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(con
 
         uint8_t length = tlv[0] & 0x18;
         if(length == 0x08) {
-        offset+= 1;
+            offset += 1;
         } else if(length == 0x10) {
-        offset+= 2;
+            offset += 2;
         } else if(length == 0x18) {
-        offset+= 3;
+            offset += 3;
         }
 
         tr_debug("M2MTLVDeserializer::deserialize_resource_instances() Offset %d", offset);
@@ -295,7 +295,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(con
                 found = true;
                 if(update_value) {
                     if(til._length > 0) {
-                    (*it)->set_value(tlv+offset, til._length);
+                        (*it)->set_value(tlv+offset, til._length);
                     } else {
                         (*it)->clear_value();
                     }
@@ -372,12 +372,8 @@ bool M2MTLVDeserializer::is_resource_instance(const uint8_t *tlv, uint32_t offse
 }
 
 TypeIdLength::TypeIdLength(const uint8_t *tlv, uint32_t offset)
+: _tlv(tlv), _offset(offset), _type(tlv[offset] & 0xC0), _id(0), _length(0)
 {
-    _tlv = tlv;
-    _offset = offset;
-    _type = tlv[offset] & 0xC0;
-    _id = 0;
-    _length = 0;
 }
 
 void TypeIdLength::deserialize()

--- a/source/m2mtlvdeserializer.cpp
+++ b/source/m2mtlvdeserializer.cpp
@@ -21,27 +21,27 @@
 #define TRACE_GROUP "mClt"
 #define BUFFER_SIZE 10
 
-bool M2MTLVDeserializer::is_object_instance(uint8_t *tlv)
+bool M2MTLVDeserializer::is_object_instance(const uint8_t *tlv)
 {
     return is_object_instance(tlv, 0);
 }
 
-bool M2MTLVDeserializer::is_resource(uint8_t *tlv)
+bool M2MTLVDeserializer::is_resource(const uint8_t *tlv)
 {
     return is_resource(tlv, 0);
 }
 
-bool M2MTLVDeserializer::is_multiple_resource(uint8_t *tlv)
+bool M2MTLVDeserializer::is_multiple_resource(const uint8_t *tlv)
 {
     return is_multiple_resource(tlv, 0);
 }
 
-bool M2MTLVDeserializer::is_resource_instance(uint8_t *tlv)
+bool M2MTLVDeserializer::is_resource_instance(const uint8_t *tlv)
 {
     return is_resource_instance(tlv, 0);
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialise_object_instances(uint8_t* tlv,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialise_object_instances(const uint8_t* tlv,
                                                                            uint32_t tlv_size,
                                                                            M2MObject &object,
                                                                            M2MTLVDeserializer::Operation operation)
@@ -60,7 +60,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialise_object_instances(uint8
     return error;
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(uint8_t *tlv,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(const uint8_t *tlv,
                                                                     uint32_t tlv_size,
                                                                     M2MObjectInstance &object_instance,
                                                                     M2MTLVDeserializer::Operation operation)
@@ -77,7 +77,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(uint8_t *tlv
     return error;
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(uint8_t *tlv,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(const uint8_t *tlv,
                                                                              uint32_t tlv_size,
                                                                              M2MResource &resource,
                                                                              M2MTLVDeserializer::Operation operation)
@@ -109,7 +109,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(uin
     return error;
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_object_instances(uint8_t *tlv,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_object_instances(const uint8_t *tlv,
                                                                            uint32_t tlv_size,
                                                                            uint32_t offset,
                                                                            M2MObject &object,
@@ -141,7 +141,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_object_instances(uint8
     return error;
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(uint8_t *tlv,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(const uint8_t *tlv,
                                                                     uint32_t tlv_size,
                                                                     uint32_t offset,
                                                                     M2MObjectInstance &object_instance,
@@ -212,7 +212,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(uint8_t *tlv
     return error;
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(uint8_t *tlv,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(const uint8_t *tlv,
                                                                              uint32_t tlv_size,
                                                                              uint32_t offset,
                                                                              M2MResource &resource,
@@ -273,7 +273,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(uin
     return error;
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(uint8_t *tlv,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(const uint8_t *tlv,
                                                                              uint32_t tlv_size,
                                                                              uint32_t offset,
                                                                              M2MResource &resource,
@@ -326,7 +326,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(uin
     return error;
 }
 
-bool M2MTLVDeserializer::is_object_instance(uint8_t *tlv, uint32_t offset)
+bool M2MTLVDeserializer::is_object_instance(const uint8_t *tlv, uint32_t offset)
 {
     bool ret = false;
     if (tlv) {
@@ -336,7 +336,7 @@ bool M2MTLVDeserializer::is_object_instance(uint8_t *tlv, uint32_t offset)
     return ret;
 }
 
-uint16_t M2MTLVDeserializer::instance_id(uint8_t *tlv)
+uint16_t M2MTLVDeserializer::instance_id(const uint8_t *tlv)
 {
     TypeIdLength til(tlv, 0);
     til.deserialize();
@@ -344,7 +344,7 @@ uint16_t M2MTLVDeserializer::instance_id(uint8_t *tlv)
     return id;
 }
 
-bool M2MTLVDeserializer::is_resource(uint8_t *tlv, uint32_t offset)
+bool M2MTLVDeserializer::is_resource(const uint8_t *tlv, uint32_t offset)
 {
     bool ret = false;
     if (tlv) {
@@ -353,7 +353,7 @@ bool M2MTLVDeserializer::is_resource(uint8_t *tlv, uint32_t offset)
     return ret;
 }
 
-bool M2MTLVDeserializer::is_multiple_resource(uint8_t *tlv, uint32_t offset)
+bool M2MTLVDeserializer::is_multiple_resource(const uint8_t *tlv, uint32_t offset)
 {
     bool ret = false;
     if (tlv) {
@@ -362,7 +362,7 @@ bool M2MTLVDeserializer::is_multiple_resource(uint8_t *tlv, uint32_t offset)
     return ret;
 }
 
-bool M2MTLVDeserializer::is_resource_instance(uint8_t *tlv, uint32_t offset)
+bool M2MTLVDeserializer::is_resource_instance(const uint8_t *tlv, uint32_t offset)
 {
     bool ret = false;
     if (tlv) {
@@ -371,7 +371,7 @@ bool M2MTLVDeserializer::is_resource_instance(uint8_t *tlv, uint32_t offset)
     return ret;
 }
 
-TypeIdLength::TypeIdLength(uint8_t *tlv, uint32_t offset)
+TypeIdLength::TypeIdLength(const uint8_t *tlv, uint32_t offset)
 {
     _tlv = tlv;
     _offset = offset;

--- a/source/m2mtlvserializer.cpp
+++ b/source/m2mtlvserializer.cpp
@@ -24,25 +24,25 @@
 #define MAX_TLV_ID_SIZE 2
 #define TLV_TYPE_SIZE 1
 
-uint8_t* M2MTLVSerializer::serialize(M2MObjectInstanceList object_instance_list, uint32_t &size)
+uint8_t* M2MTLVSerializer::serialize(const M2MObjectInstanceList &object_instance_list, uint32_t &size)
 {
     return serialize_object_instances(object_instance_list, size);
 }
 
-uint8_t* M2MTLVSerializer::serialize(M2MResourceList resource_list, uint32_t &size)
+uint8_t* M2MTLVSerializer::serialize(const M2MResourceList &resource_list, uint32_t &size)
 {
     bool valid = true;
     return serialize_resources(resource_list, size,valid);
 }
 
-uint8_t* M2MTLVSerializer::serialize(M2MResource *resource, uint32_t &size)
+uint8_t* M2MTLVSerializer::serialize(const M2MResource *resource, uint32_t &size)
 {
     uint8_t* data = NULL;
     serialize(resource, data, size);
     return data;
 }
 
-uint8_t* M2MTLVSerializer::serialize_object_instances(M2MObjectInstanceList object_instance_list, uint32_t &size)
+uint8_t* M2MTLVSerializer::serialize_object_instances(const M2MObjectInstanceList &object_instance_list, uint32_t &size)
 {
     uint8_t *data = NULL;
 
@@ -57,7 +57,7 @@ uint8_t* M2MTLVSerializer::serialize_object_instances(M2MObjectInstanceList obje
     return data;
 }
 
-uint8_t* M2MTLVSerializer::serialize_resources(M2MResourceList resource_list, uint32_t &size, bool &valid)
+uint8_t* M2MTLVSerializer::serialize_resources(const M2MResourceList &resource_list, uint32_t &size, bool &valid)
 {
     uint8_t *data = NULL;
 
@@ -88,7 +88,7 @@ uint8_t* M2MTLVSerializer::serialize_resources(M2MResourceList resource_list, ui
     return data;
 }
 
-bool M2MTLVSerializer::serialize(uint16_t id, M2MObjectInstance *object_instance, uint8_t *&data, uint32_t &size)
+bool M2MTLVSerializer::serialize(uint16_t id, const M2MObjectInstance *object_instance, uint8_t *&data, uint32_t &size)
 {
     uint8_t *resource_data = NULL;
     uint32_t resource_size = 0;
@@ -111,7 +111,7 @@ bool M2MTLVSerializer::serialize(uint16_t id, M2MObjectInstance *object_instance
     return success;
 }
 
-bool M2MTLVSerializer::serialize(M2MResource *resource, uint8_t *&data, uint32_t &size)
+bool M2MTLVSerializer::serialize(const M2MResource *resource, uint8_t *&data, uint32_t &size)
 {
     bool success = false;
     if(resource->name_id() != -1) {
@@ -122,7 +122,7 @@ bool M2MTLVSerializer::serialize(M2MResource *resource, uint8_t *&data, uint32_t
     return success;
 }
 
-bool M2MTLVSerializer::serialize_resource(M2MResource *resource, uint8_t *&data, uint32_t &size)
+bool M2MTLVSerializer::serialize_resource(const M2MResource *resource, uint8_t *&data, uint32_t &size)
 {
     bool success = false;
     if(resource->name_id() != -1) {
@@ -132,7 +132,7 @@ bool M2MTLVSerializer::serialize_resource(M2MResource *resource, uint8_t *&data,
     return success;
 }
 
-bool M2MTLVSerializer::serialize_multiple_resource(M2MResource *resource, uint8_t *&data, uint32_t &size)
+bool M2MTLVSerializer::serialize_multiple_resource(const M2MResource *resource, uint8_t *&data, uint32_t &size)
 {
     bool success = false;
     uint8_t *nested_data = NULL;
@@ -164,7 +164,7 @@ bool M2MTLVSerializer::serialize_multiple_resource(M2MResource *resource, uint8_
     return success;
 }
 
-bool M2MTLVSerializer::serialize_resource_instance(uint16_t id, M2MResourceInstance *resource, uint8_t *&data, uint32_t &size)
+bool M2MTLVSerializer::serialize_resource_instance(uint16_t id, const M2MResourceInstance *resource, uint8_t *&data, uint32_t &size)
 {
     return serialize_TILV(TYPE_RESOURCE_INSTANCE, id, resource->value(), resource->value_length(), data, size);
 }

--- a/test/mbedclient/utest/includes.txt
+++ b/test/mbedclient/utest/includes.txt
@@ -10,6 +10,7 @@ include_directories(
 	"../../../../yotta_modules/mbed-client-linux/mbed-client-linux"
         "../../../../yotta_modules/mbed-client-mbed-os"
 	"../../../../yotta_modules/mbed-client-c"
+	"../../../../yotta_modules/mbed-trace"
 	"usr/include"
 	"$ENV{CPPUTEST_HOME}/include"
 )

--- a/test/mbedclient/utest/m2mbase/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mbase/CMakeLists.txt
@@ -1,19 +1,20 @@
 if(TARGET_LIKE_LINUX)
 include("../includes.txt")
 add_executable(m2mbase 
-	"../../../../source/m2mbase.cpp"
-	"main.cpp"
-    "../stub/m2mreporthandler_stub.cpp"
-    "../stub/nsdlaccesshelper_stub.cpp"
-    "../stub/m2mresource_stub.cpp"
-    "../stub/m2mresourceinstance_stub.cpp"
-    "../stub/m2mstring_stub.cpp"
-    "../stub/m2mtimer_stub.cpp"
-    "../stub/m2mobject_stub.cpp"
-    "../stub/m2mobjectinstance_stub.cpp"
-    "../stub/m2mresource_stub.cpp"
-	"m2mbasetest.cpp"
-	"test_m2mbase.cpp"
+       "../../../../source/m2mbase.cpp"
+        "main.cpp"
+        "../stub/m2mreporthandler_stub.cpp"
+        "../stub/nsdlaccesshelper_stub.cpp"
+        "../stub/m2mresource_stub.cpp"
+        "../stub/m2mresourceinstance_stub.cpp"
+        "../stub/m2mstring_stub.cpp"
+        "../stub/m2mtimer_stub.cpp"
+        "../stub/m2mobject_stub.cpp"
+        "../stub/m2mobjectinstance_stub.cpp"
+        "../stub/m2mresource_stub.cpp"
+        "../stub/mbed_trace_stub.cpp"
+        "m2mbasetest.cpp"
+        "test_m2mbase.cpp"
         "../../../../source/m2mstringbufferbase.cpp"
 )
 target_link_libraries(m2mbase

--- a/test/mbedclient/utest/m2minterfacefactory/CMakeLists.txt
+++ b/test/mbedclient/utest/m2minterfacefactory/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(m2minterfacefactorytest
         "../stub/m2mconnectionhandler_stub.cpp"
         "../stub/m2mconnectionsecurity_stub.cpp"
         "../stub/nsdlaccesshelper_stub.cpp"
+        "../stub/mbed_trace_stub.cpp"
         "../../../../source/m2minterfacefactory.cpp"
         "../../../../source/m2mstringbufferbase.cpp"
 )

--- a/test/mbedclient/utest/m2minterfaceimpl/CMakeLists.txt
+++ b/test/mbedclient/utest/m2minterfaceimpl/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(m2minterfaceimpl
         "../stub/m2mconnectionsecurity_stub.cpp"
         "../stub/nsdlaccesshelper_stub.cpp"
         "../stub/m2mserver_stub.cpp"
+        "../stub/mbed_trace_stub.cpp"
         "../../../../source/m2minterfaceimpl.cpp"
         "../../../../source/m2mstringbufferbase.cpp"
 )

--- a/test/mbedclient/utest/m2mnsdlinterface/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mnsdlinterface/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(m2mnsdlinterface
         "../stub/nsdlaccesshelper_stub.cpp"
         "../stub/m2mtlvserializer_stub.cpp"
         "../stub/m2mtlvdeserializer_stub.cpp"
+        "../stub/mbed_trace_stub.cpp"
         "../../../../source/m2mnsdlinterface.cpp"
         "../../../../source/m2mstringbufferbase.cpp"
 )

--- a/test/mbedclient/utest/m2mobject/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mobject/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(m2mobject
         "../stub/nsdlaccesshelper_stub.cpp"
         "../../../../source/m2mobject.cpp"
         "../stub/m2mtimer_stub.cpp"
+        "../stub/mbed_trace_stub.cpp"
         "../../../../source/m2mstringbufferbase.cpp"
 )
 target_link_libraries(m2mobject

--- a/test/mbedclient/utest/m2mobjectinstance/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mobjectinstance/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(m2mobjectinstance
         "../stub/nsdlaccesshelper_stub.cpp"
         "../../../../source/m2mobjectinstance.cpp"
         "../../../../source/m2mstringbufferbase.cpp"
+        "../stub/mbed_trace_stub.cpp"
 )
 target_link_libraries(m2mobjectinstance
     CppUTest

--- a/test/mbedclient/utest/m2mreporthandler/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mreporthandler/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(m2mreporthandler
         "test_m2mreporthandler.cpp"
         "../stub/m2mtimer_stub.cpp"
         "../stub/m2mstring_stub.cpp"
+        "../stub/mbed_trace_stub.cpp"
         "../../../../source/m2mreporthandler.cpp"
 
 )

--- a/test/mbedclient/utest/m2mresource/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mresource/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(m2mresource
         "../stub/m2mtlvserializer_stub.cpp"
         "../stub/nsdlaccesshelper_stub.cpp"
         "../stub/common_stub.cpp"
+        "../stub/mbed_trace_stub.cpp"
         "m2mresourcetest.cpp"
         "test_m2mresource.cpp"
         "../../../../source/m2mstringbufferbase.cpp"

--- a/test/mbedclient/utest/m2mresourceinstance/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mresourceinstance/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(m2mresourceinstance
         "../stub/nsdlaccesshelper_stub.cpp"
         "../stub/m2mresource_stub.cpp"
         "../stub/m2mobject_stub.cpp"
+        "../stub/mbed_trace_stub.cpp"
         "m2mresourceinstancetest.cpp"
         "test_m2mresourceinstance.cpp"
         "../../../../source/m2mstringbufferbase.cpp"

--- a/test/mbedclient/utest/m2mtlvdeserializer/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mtlvdeserializer/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(m2mtlv
         "../stub/m2mobjectinstance_stub.cpp"
         "../stub/m2mobject_stub.cpp"
         "../stub/nsdlaccesshelper_stub.cpp"
+        "../stub/mbed_trace_stub.cpp"
         "test_m2mtlvserializer.cpp"
         "../../../../source/m2mstringbufferbase.cpp"
 )

--- a/test/mbedclient/utest/m2mtlvdeserializer/test_m2mtlvserializer.cpp
+++ b/test/mbedclient/utest/m2mtlvdeserializer/test_m2mtlvserializer.cpp
@@ -63,8 +63,6 @@ void Test_M2MTLVSerializer::test_serialize_object_out_of_memory()
 
     m2mobject_stub::instance_list.push_back(instance);
 
-
-
     M2MResource* resource = new M2MResource(*instance,
                                             "1",
                                             "type",
@@ -77,12 +75,12 @@ void Test_M2MTLVSerializer::test_serialize_object_out_of_memory()
 
     m2mbase_stub::name_id_value = 0;
     memory_fail_counter=1; //apply for 1 time failing malloc
-    memory_will_fail_counter=3; //after 3 successful ones
+    memory_will_fail_counter=0; //after 0 successful ones
     data = serializer->serialize( m2mobject_stub::instance_list,size);
     CHECK(data == NULL);
 
     memory_fail_counter=1; //apply for 1 time failing malloc
-    memory_will_fail_counter=4; //after 4 successful ones
+    memory_will_fail_counter=1; //after 1 successful ones
     data = serializer->serialize( m2mobject_stub::instance_list,size);
     CHECK(data == NULL);
 
@@ -106,6 +104,16 @@ void Test_M2MTLVSerializer::test_serialize_object_out_of_memory()
     m2mresource_stub::list.push_back(res_instance);
     m2mresource_stub::list.push_back(res_instance_1);
     memory_fail_counter=1; //apply for 1 time failing malloc
+    memory_will_fail_counter=2; //after 2 successful ones
+    data = serializer->serialize( m2mobject_stub::instance_list,size);
+    CHECK(data == NULL);
+
+    memory_fail_counter=1; //apply for 1 time failing malloc
+    memory_will_fail_counter=3; //after 3 successful ones
+    data = serializer->serialize( m2mobject_stub::instance_list,size);
+    CHECK(data == NULL);
+
+    memory_fail_counter=1; //apply for 1 time failing malloc
     memory_will_fail_counter=4; //after 4 successful ones
     data = serializer->serialize( m2mobject_stub::instance_list,size);
     CHECK(data == NULL);
@@ -113,17 +121,15 @@ void Test_M2MTLVSerializer::test_serialize_object_out_of_memory()
     memory_fail_counter=1; //apply for 1 time failing malloc
     memory_will_fail_counter=5; //after 5 successful ones
     data = serializer->serialize( m2mobject_stub::instance_list,size);
-    CHECK(data == NULL);
+    // the data was actually encoded 
+    CHECK(data != NULL);
 
-    memory_fail_counter=1; //apply for 1 time failing malloc
-    memory_will_fail_counter=6; //after 6 successful ones
-    data = serializer->serialize( m2mobject_stub::instance_list,size);
-    CHECK(data == NULL);
+    free(data);
 
-    memory_fail_counter=1; //apply for 1 time failing malloc
-    memory_will_fail_counter=7; //after 7 successful ones
-    data = serializer->serialize( m2mobject_stub::instance_list,size);
-    CHECK(data == NULL);
+    // Disable the failures in allocator as the cpputest will otherwise panic 
+    // on its own cleanup which does allocation.
+    memory_fail_counter = 0;
+    memory_will_fail_counter = 0;
 
     delete res_instance_1;
     delete res_instance;
@@ -445,12 +451,12 @@ void Test_M2MTLVSerializer::test_serialize_resource_instance_out_of_memory()
 
     m2mbase_stub::operation = M2MBase::GET_ALLOWED;
     memory_fail_counter=1; //apply for 1 time failing malloc
-    memory_will_fail_counter=3; //after 3 successful ones
+    memory_will_fail_counter=1; //after 1 successful ones
     data = serializer->serialize( m2mobjectinstance_stub::resource_list,size);
     CHECK(data == NULL);
 
     memory_fail_counter=1; //apply for 1 time failing malloc
-    memory_will_fail_counter=4; //after 4 successful ones
+    memory_will_fail_counter=2; //after 2 successful ones
     data = serializer->serialize( m2mobjectinstance_stub::resource_list,size);
     CHECK(data == NULL);
 

--- a/test/mbedclient/utest/stub/m2mtlvdeserializer_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mtlvdeserializer_stub.cpp
@@ -28,27 +28,27 @@ void m2mtlvdeserializer_stub::clear()
     int_value = 0;
 }
 
-bool M2MTLVDeserializer::is_object_instance(uint8_t *)
+bool M2MTLVDeserializer::is_object_instance(const uint8_t *)
 {
     return m2mtlvdeserializer_stub::is_object_bool_value;
 }
 
-bool M2MTLVDeserializer::is_resource(uint8_t *)
+bool M2MTLVDeserializer::is_resource(const uint8_t *)
 {
     return m2mtlvdeserializer_stub::bool_value;
 }
 
-bool M2MTLVDeserializer::is_multiple_resource(uint8_t *)
+bool M2MTLVDeserializer::is_multiple_resource(const uint8_t *)
 {
     return m2mtlvdeserializer_stub::bool_value;
 }
 
-bool M2MTLVDeserializer::is_resource_instance(uint8_t *)
+bool M2MTLVDeserializer::is_resource_instance(const uint8_t *)
 {
     return m2mtlvdeserializer_stub::bool_value;
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(uint8_t*,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(const uint8_t *,
                                                                     uint32_t,
                                                                     M2MObjectInstance &,
                                                                     M2MTLVDeserializer::Operation )
@@ -56,7 +56,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resources(uint8_t*,
     return m2mtlvdeserializer_stub::error;
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(uint8_t *,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(const uint8_t *,
                                                                              uint32_t,
                                                                              M2MResource &,
                                                                              M2MTLVDeserializer::Operation )
@@ -64,7 +64,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(uin
     return m2mtlvdeserializer_stub::error;
 }
 
-M2MTLVDeserializer::Error M2MTLVDeserializer::deserialise_object_instances(uint8_t*,
+M2MTLVDeserializer::Error M2MTLVDeserializer::deserialise_object_instances(const uint8_t *,
                                                                            uint32_t ,
                                                                            M2MObject &,
                                                                            M2MTLVDeserializer::Operation)
@@ -72,7 +72,7 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialise_object_instances(uint8
     return m2mtlvdeserializer_stub::error;
 }
 
-TypeIdLength::TypeIdLength(uint8_t *, uint32_t)
+TypeIdLength::TypeIdLength(const uint8_t *, uint32_t)
 {
 }
 
@@ -88,7 +88,7 @@ void TypeIdLength::deserialiseLength(uint32_t lengthType)
 {
 }
 
-uint16_t M2MTLVDeserializer::instance_id(uint8_t *tlv)
+uint16_t M2MTLVDeserializer::instance_id(const uint8_t *tlv)
 {
     return m2mtlvdeserializer_stub::int_value;
 }

--- a/test/mbedclient/utest/stub/m2mtlvserializer_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mtlvserializer_stub.cpp
@@ -22,17 +22,17 @@ void m2mtlvserializer_stub::clear()
     uint8_value = NULL;
 }
 
-uint8_t* M2MTLVSerializer::serialize(M2MObjectInstanceList object_instance_list, uint32_t &)
+uint8_t* M2MTLVSerializer::serialize(const M2MObjectInstanceList &object_instance_list, uint32_t &)
 {
     return m2mtlvserializer_stub::uint8_value;
 }
 
-uint8_t* M2MTLVSerializer::serialize(M2MResourceList resource_list, uint32_t &size)
+uint8_t* M2MTLVSerializer::serialize(const M2MResourceList &resource_list, uint32_t &size)
 {
     return m2mtlvserializer_stub::uint8_value;
 }
 
-uint8_t* M2MTLVSerializer::serialize(M2MResource *, uint32_t &)
+uint8_t* M2MTLVSerializer::serialize(const M2MResource *, uint32_t &)
 {
     return m2mtlvserializer_stub::uint8_value;
 }

--- a/test/mbedclient/utest/stub/mbed_trace_stub.cpp
+++ b/test/mbedclient/utest/stub/mbed_trace_stub.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdlib.h>
+
+#ifndef YOTTA_CFG_MBED_TRACE
+#define YOTTA_CFG_MBED_TRACE 1
+#define YOTTA_CFG_MBED_TRACE_FEA_IPV6 1
+#endif
+
+#include "mbed-trace/mbed_trace.h"
+#if YOTTA_CFG_MBED_TRACE_FEA_IPV6 == 1
+#include "mbed-client-libservice/ip6string.h"
+#include "mbed-client-libservice/common_functions.h"
+#endif
+
+
+int mbed_trace_init(void)
+{
+    return 0;
+}
+void mbed_trace_free(void)
+{
+}
+
+void mbed_trace_buffer_sizes(int lineLength, int tmpLength)
+{
+}
+
+void mbed_trace_config_set(uint8_t config)
+{
+}
+
+uint8_t mbed_trace_config_get(void)
+{
+    return 0;
+}
+
+void mbed_trace_prefix_function_set(char *(*pref_f)(size_t))
+{
+}
+
+void mbed_trace_suffix_function_set(char *(*suffix_f)(void))
+{
+}
+
+void mbed_trace_print_function_set(void (*printf)(const char *))
+{
+}
+
+void mbed_trace_cmdprint_function_set(void (*printf)(const char *))
+{
+}
+
+void mbed_trace_exclude_filters_set(char *filters)
+{
+
+}
+
+const char *mbed_trace_exclude_filters_get(void)
+{
+    return NULL;
+}
+
+const char *mbed_trace_include_filters_get(void)
+{
+    return NULL;
+}
+
+void mbed_trace_include_filters_set(char *filters)
+{
+
+}
+
+void mbed_tracef(uint8_t dlevel, const char *grp, const char *fmt, ...)
+{
+}
+
+const char *mbed_trace_last(void)
+{
+    return NULL;
+}
+
+/* Helping functions */
+#define tmp_data_left()  m_trace.tmp_data_length-(m_trace.tmp_data_ptr-m_trace.tmp_data)
+#if YOTTA_CFG_MBED_TRACE_FEA_IPV6 == 1
+char *mbed_trace_ipv6(const void *addr_ptr)
+{
+    return NULL;
+}
+
+char *mbed_trace_ipv6_prefix(const uint8_t *prefix, uint8_t prefix_len)
+{
+    return NULL;
+}
+#endif //YOTTA_CFG_MBED_TRACE_FEA_IPV6
+
+char *mbed_trace_array(const uint8_t *buf, uint16_t len)
+{
+    return NULL;
+}


### PR DESCRIPTION
Minor cleanups by constifying params and using reference instead of copies in few places.