### PR TITLE
Add support for TLV binary integer

### DIFF
--- a/mbed-client/m2mresourceinstance.h
+++ b/mbed-client/m2mresourceinstance.h
@@ -199,7 +199,7 @@ public:
      * \brief Converts a value to integer and returns it. Note: Conversion
      * errors are not detected.
      */
-    int get_value_int();
+    int64_t get_value_int() const;
 
     /**
      * Get the value as a string object. No encoding/charset conversions

--- a/module.json
+++ b/module.json
@@ -8,7 +8,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "mbed-client-c": "^5.0.0",
-    "mbed-trace": ">=0.2.0,<2.0.0"
+    "mbed-trace": ">=0.2.0,<2.0.0",
+    "nanostack-libservice": "^3.0.0"
   },
   "targetDependencies": {
     "arm": {

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -32,7 +32,8 @@ find ./build -name '*.xml' | xargs cp -t ./results/
 find ./build/x86-linux-native-coverage/test -name '*.gcno' | xargs cp -t ./coverage/
 find ./build/x86-linux-native-coverage/test -name '*.gcda' | xargs cp -t ./coverage/
 touch coverage/*.gcda
-exclude_files="${PWD}/test/"
+exclude_files="${PWD}/test/|${PWD}/yotta_modules*"
+#exclude_files2="${PWD}/yotta_modules*"
 gcovr -r ./ --gcov-filter='.*source*.' --exclude-unreachable-branches --exclude $exclude_files --object-directory ./coverage -x -o ./results/gcovr.xml
 echo
 echo "Create coverage document"

--- a/source/include/m2mtlvserializer.h
+++ b/source/include/m2mtlvserializer.h
@@ -97,4 +97,5 @@ private :
     static void serialize_length(uint32_t length, uint32_t &size, uint8_t *length_ptr);
 
     template <typename T> static void set_value_int(T value, uint8_t *buffer, uint32_t &size);
+    template <typename T> static bool serialize_TLV_binary_int(T *resource, uint8_t type, uint16_t id, uint8_t *&data, uint32_t &size);
 };

--- a/source/include/m2mtlvserializer.h
+++ b/source/include/m2mtlvserializer.h
@@ -97,5 +97,5 @@ private :
     static void serialize_length(uint32_t length, uint32_t &size, uint8_t *length_ptr);
 
     template <typename T> static void set_value_int(T value, uint8_t *buffer, uint32_t &size);
-    template <typename T> static bool serialize_TLV_binary_int(T *resource, uint8_t type, uint16_t id, uint8_t *&data, uint32_t &size);
+    static bool serialize_TLV_binary_int(const M2MResourceInstance *resource, uint8_t type, uint16_t id, uint8_t *&data, uint32_t &size);
 };

--- a/source/include/m2mtlvserializer.h
+++ b/source/include/m2mtlvserializer.h
@@ -96,6 +96,5 @@ private :
 
     static void serialize_length(uint32_t length, uint32_t &size, uint8_t *length_ptr);
 
-    template <typename T> static void set_value_int(T value, uint8_t *buffer, uint32_t &size);
     static bool serialize_TLV_binary_int(const M2MResourceInstance *resource, uint8_t type, uint16_t id, uint8_t *&data, uint32_t &size);
 };

--- a/source/include/m2mtlvserializer.h
+++ b/source/include/m2mtlvserializer.h
@@ -95,4 +95,6 @@ private :
     static void serialize_id(uint16_t id, uint32_t &size, uint8_t *id_ptr);
 
     static void serialize_length(uint32_t length, uint32_t &size, uint8_t *length_ptr);
+
+    template <typename T> static void set_value_int(T value, uint8_t *buffer, uint32_t &size);
 };

--- a/source/m2mresourceinstance.cpp
+++ b/source/m2mresourceinstance.cpp
@@ -337,17 +337,13 @@ void M2MResourceInstance::get_value(uint8_t *&value, uint32_t &value_length)
     }
 }
 
-int M2MResourceInstance::get_value_int()
+int64_t M2MResourceInstance::get_value_int() const
 {
     int value_int = 0;
-    // Get the value and convert it into integer. This is not the most
-    // efficient way, as it takes pointless heap copy to get the zero termination.
-    uint8_t* buffer = NULL;
-    uint32_t length;
-    get_value(buffer,length);
+    uint8_t* buffer = _value;
+
     if(buffer) {
         value_int = atoi((const char*)buffer);
-        free(buffer);
     }
     return value_int;
 }

--- a/source/m2mresourceinstance.cpp
+++ b/source/m2mresourceinstance.cpp
@@ -340,10 +340,9 @@ void M2MResourceInstance::get_value(uint8_t *&value, uint32_t &value_length)
 int64_t M2MResourceInstance::get_value_int() const
 {
     int64_t value_int = 0;
-    uint8_t* buffer = _value;
 
-    if(buffer) {
-        value_int = atoll((const char*)buffer);
+    if(_value) {
+        value_int = atoll((const char*)_value);
     }
     return value_int;
 }

--- a/source/m2mresourceinstance.cpp
+++ b/source/m2mresourceinstance.cpp
@@ -339,11 +339,11 @@ void M2MResourceInstance::get_value(uint8_t *&value, uint32_t &value_length)
 
 int64_t M2MResourceInstance::get_value_int() const
 {
-    int value_int = 0;
+    int64_t value_int = 0;
     uint8_t* buffer = _value;
 
     if(buffer) {
-        value_int = atoi((const char*)buffer);
+        value_int = atoll((const char*)buffer);
     }
     return value_int;
 }

--- a/source/m2mtlvserializer.cpp
+++ b/source/m2mtlvserializer.cpp
@@ -127,7 +127,8 @@ bool M2MTLVSerializer::serialize_resource(const M2MResource *resource, uint8_t *
     bool success = false;
     if(resource->name_id() != -1) {
         if ( (resource->resource_instance_type() == M2MResourceInstance::INTEGER) ||
-           ( resource->resource_instance_type() == M2MResourceInstance::BOOLEAN)) {
+             (resource->resource_instance_type() == M2MResourceInstance::BOOLEAN) ||
+             (resource->resource_instance_type() == M2MResourceInstance::TIME) ) {
             success = serialize_TLV_binary_int(resource, TYPE_RESOURCE, resource->name_id(), data, size);
         }
         else {
@@ -194,7 +195,8 @@ bool M2MTLVSerializer::serialize_resource_instance(uint16_t id, const M2MResourc
     bool success;
 
     if ( (resource->resource_instance_type() == M2MResourceInstance::INTEGER) ||
-        ( resource->resource_instance_type() == M2MResourceInstance::BOOLEAN)) {
+         (resource->resource_instance_type() == M2MResourceInstance::BOOLEAN) ||
+         (resource->resource_instance_type() == M2MResourceInstance::TIME) ) {
         success=serialize_TLV_binary_int(resource, TYPE_RESOURCE_INSTANCE, id, data, size);
         }
     else {

--- a/source/m2mtlvserializer.cpp
+++ b/source/m2mtlvserializer.cpp
@@ -126,8 +126,21 @@ bool M2MTLVSerializer::serialize_resource(const M2MResource *resource, uint8_t *
 {
     bool success = false;
     if(resource->name_id() != -1) {
-        success = serialize_TILV(TYPE_RESOURCE, resource->name_id(),
+        if ( resource->resource_instance_type() == M2MResourceInstance::INTEGER) {
+            int64_t valueInt = resource->get_value_int();
+            uint32_t buf_size;
+            /* max len 8 bytes */
+            uint8_t buffer[8];
+
+            // write bytes to big endian order in buffer
+            set_value_int(valueInt, buffer, buf_size);
+            success = serialize_TILV(TYPE_RESOURCE, resource->name_id(),
+                       buffer, buf_size, data, size);
+        }
+        else {
+             success = serialize_TILV(TYPE_RESOURCE, resource->name_id(),
                       resource->value(), resource->value_length(), data, size);
+        }
     }
     return success;
 }
@@ -164,9 +177,44 @@ bool M2MTLVSerializer::serialize_multiple_resource(const M2MResource *resource, 
     return success;
 }
 
+/* See, OMA-TS-LightweightM2M-V1_0-20170208-A, Appendix C,
+ * Data Types, Integer, TLV Format 
+ * 
+ * This is easy to change to support 8, 16 or 32 interger. */
+template <typename T> void M2MTLVSerializer::set_value_int(T value, uint8_t *buffer, uint32_t &size)
+{
+    size = sizeof(value);
+
+    /* write bytes to big endian order in buffer */
+    for (uint8_t ind=0;ind<size;ind++) {
+        buffer[size-ind-1] = ((value >> (ind*8)) & 0xFF);
+    }
+}
+
+template void M2MTLVSerializer::set_value_int<int8_t>(int8_t value, uint8_t *buffer, uint32_t &size);
+template void M2MTLVSerializer::set_value_int<int16_t>(int16_t value, uint8_t *buffer, uint32_t &size);
+template void M2MTLVSerializer::set_value_int<int32_t>(int32_t value, uint8_t *buffer, uint32_t &size);
+template void M2MTLVSerializer::set_value_int<int64_t>(int64_t value, uint8_t *buffer, uint32_t &size);
+
 bool M2MTLVSerializer::serialize_resource_instance(uint16_t id, const M2MResourceInstance *resource, uint8_t *&data, uint32_t &size)
 {
-    return serialize_TILV(TYPE_RESOURCE_INSTANCE, id, resource->value(), resource->value_length(), data, size);
+    bool success;
+
+    if ( resource->resource_instance_type() == M2MResourceInstance::INTEGER) {
+        int64_t valueInt = resource->get_value_int();
+        uint32_t buf_size;
+        /* max len 8 bytes */
+        uint8_t buffer[8];
+
+        // write bytes to big endian order in buffer
+        set_value_int(valueInt, buffer, buf_size);
+        success=serialize_TILV(TYPE_RESOURCE_INSTANCE, id, buffer, buf_size, data, size);
+    }
+    else {
+        success=serialize_TILV(TYPE_RESOURCE_INSTANCE, id, resource->value(), resource->value_length(), data, size);
+    }
+
+    return success;
 }
 
 bool M2MTLVSerializer::serialize_TILV(uint8_t type, uint16_t id, uint8_t *value, uint32_t value_length, uint8_t *&data, uint32_t &size)

--- a/source/m2mtlvserializer.cpp
+++ b/source/m2mtlvserializer.cpp
@@ -206,7 +206,7 @@ bool M2MTLVSerializer::serialize_resource_instance(uint16_t id, const M2MResourc
     return success;
 }
 
-template <typename T> bool M2MTLVSerializer::serialize_TLV_binary_int(T *resource, uint8_t type, uint16_t id, uint8_t *&data, uint32_t &size)
+bool M2MTLVSerializer::serialize_TLV_binary_int(const M2MResourceInstance *resource, uint8_t type, uint16_t id, uint8_t *&data, uint32_t &size)
 {
         int64_t valueInt = resource->get_value_int();
         uint32_t buffer_size;
@@ -223,8 +223,6 @@ template <typename T> bool M2MTLVSerializer::serialize_TLV_binary_int(T *resourc
         return serialize_TILV(type, id, buffer, buffer_size, data, size);
 }
 
-template bool M2MTLVSerializer::serialize_TLV_binary_int<const M2MResourceInstance>(const M2MResourceInstance *resource, uint8_t type, uint16_t id, uint8_t *&data, uint32_t &size);
-template bool M2MTLVSerializer::serialize_TLV_binary_int<const M2MResource>(const M2MResource *resource, uint8_t type, uint16_t id, uint8_t *&data, uint32_t &size);
 
 bool M2MTLVSerializer::serialize_TILV(uint8_t type, uint16_t id, uint8_t *value, uint32_t value_length, uint8_t *&data, uint32_t &size)
 {

--- a/test/mbedclient/utest/m2mtlvdeserializer/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mtlvdeserializer/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(m2mtlv
 target_link_libraries(m2mtlv
     CppUTest
     CppUTestExt
+    nanostack-libservice
 )
 set_target_properties(m2mtlv
 PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS}"

--- a/test/mbedclient/utest/stub/m2mresourceinstance_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mresourceinstance_stub.cpp
@@ -170,20 +170,16 @@ void M2MResourceInstance::get_value(uint8_t *&value, uint32_t &value_length)
     }
 }
 
-int M2MResourceInstance::get_value_int()
+int64_t M2MResourceInstance::get_value_int() const
 {
     // Note: this is a copy-paste from the original version, as the tests
     // set only m2mresourceinstance_stub::value.
 
     int value_int = 0;
-    // Get the value and convert it into integer. This is not the most
-    // efficient way, as it takes pointless heap copy to get the zero termination.
-    uint8_t* buffer = NULL;
-    uint32_t length;
-    get_value(buffer,length);
+    uint8_t* buffer = m2mresourceinstance_stub::value;
+
     if(buffer) {
         value_int = atoi((const char*)buffer);
-        free(buffer);
     }
     return value_int;
 }


### PR DESCRIPTION
If resource type is INTEGER then value will convert to 64-bit binary buffer. Format is two's complement big endian word. See, OMA-TS-LightweightM2M-V1_0-20170208-A, Appendix C, data Types, Integer, TLV Format.