### PR TITLE
m2m: Fixes for the observations.

### DIFF
--- a/source/m2mobject.cpp
+++ b/source/m2mobject.cpp
@@ -253,11 +253,6 @@ sn_coap_hdr_s* M2MObject::handle_get_request(nsdl_s *nsdl,
                                     if(received_coap_header->options_list_ptr->observe != -1) {
                                         number = received_coap_header->options_list_ptr->observe;
                                     }
-                                    if(received_coap_header->token_ptr) {
-                                        tr_debug("M2MObject::handle_get_request - Sets Observation Token to resource");
-                                        set_observation_token(received_coap_header->token_ptr,
-                                                              received_coap_header->token_len);
-                                    }
 
                                     // If the observe value is 0 means register for observation.
                                     if(number == 0) {
@@ -266,6 +261,12 @@ sn_coap_hdr_s* M2MObject::handle_get_request(nsdl_s *nsdl,
                                         add_observation_level(M2MBase::O_Attribute);
                                         tr_debug("M2MObject::handle_get_request - Observation Number %d", observation_number());
                                         coap_response->options_list_ptr->observe = observation_number();
+                                    }
+
+                                    if(received_coap_header->token_ptr) {
+                                        tr_debug("M2MObject::handle_get_request - Sets Observation Token to resource");
+                                        set_observation_token(received_coap_header->token_ptr,
+                                                              received_coap_header->token_len);
                                     }
                                 } else if (STOP_OBSERVATION == observe_option) {
                                     tr_debug("M2MObject::handle_get_request - Stops Observation");

--- a/source/m2mobjectinstance.cpp
+++ b/source/m2mobjectinstance.cpp
@@ -480,11 +480,6 @@ sn_coap_hdr_s* M2MObjectInstance::handle_get_request(nsdl_s *nsdl,
                                     if(received_coap_header->options_list_ptr->observe != -1) {
                                         number = received_coap_header->options_list_ptr->observe;
                                     }
-                                    if(received_coap_header->token_ptr) {
-                                        tr_debug("M2MObjectInstance::handle_get_request - Sets Observation Token to resource");
-                                        set_observation_token(received_coap_header->token_ptr,
-                                                              received_coap_header->token_len);
-                                    }
 
                                     // If the observe value is 0 means register for observation.
                                     if(number == 0) {
@@ -493,6 +488,13 @@ sn_coap_hdr_s* M2MObjectInstance::handle_get_request(nsdl_s *nsdl,
                                         add_observation_level(M2MBase::OI_Attribute);
                                         coap_response->options_list_ptr->observe = observation_number();
                                     }
+
+                                    if(received_coap_header->token_ptr) {
+                                        tr_debug("M2MObjectInstance::handle_get_request - Sets Observation Token to resource");
+                                        set_observation_token(received_coap_header->token_ptr,
+                                                              received_coap_header->token_len);
+                                    }
+
                                 } else if (STOP_OBSERVATION == observe_option) {
                                     tr_debug("M2MObjectInstance::handle_get_request - Stops Observation");
                                     set_under_observation(false,NULL);

--- a/source/m2mresource.cpp
+++ b/source/m2mresource.cpp
@@ -331,12 +331,7 @@ sn_coap_hdr_s* M2MResource::handle_get_request(nsdl_s *nsdl,
                                     if(received_coap_header->options_list_ptr->observe != -1) {
                                         number = received_coap_header->options_list_ptr->observe;
                                     }
-                                    if(received_coap_header->token_ptr) {
-                                        tr_debug("M2MResource::handle_get_request - Sets Observation Token to resource");
-                                        set_observation_token(received_coap_header->token_ptr,
-                                                              received_coap_header->token_len);
-                                    }
-
+                                    
                                     // If the observe value is 0 means register for observation.
                                     if(number == 0) {
                                         tr_debug("M2MResource::handle_get_request - Put Resource under Observation");
@@ -349,6 +344,13 @@ sn_coap_hdr_s* M2MResource::handle_get_request(nsdl_s *nsdl,
                                         M2MBase::add_observation_level(M2MBase::R_Attribute);
                                         coap_response->options_list_ptr->observe = observation_number();
                                     }
+
+                                    if(received_coap_header->token_ptr) {
+                                        tr_debug("M2MResource::handle_get_request - Sets Observation Token to resource");
+                                        set_observation_token(received_coap_header->token_ptr,
+                                                              received_coap_header->token_len);
+                                    }
+
                                 } else if (STOP_OBSERVATION == observe_option) {
                                     tr_debug("M2MResource::handle_get_request - Stops Observation");
                                     set_under_observation(false,NULL);

--- a/source/m2mresourceinstance.cpp
+++ b/source/m2mresourceinstance.cpp
@@ -433,11 +433,7 @@ sn_coap_hdr_s* M2MResourceInstance::handle_get_request(nsdl_s *nsdl,
                                 if(received_coap_header->options_list_ptr->observe != -1) {
                                     number = received_coap_header->options_list_ptr->observe;
                                 }
-                                if(received_coap_header->token_ptr) {
-                                    tr_debug("M2MResourceInstance::handle_get_request - Sets Observation Token to resource");
-                                    set_observation_token(received_coap_header->token_ptr,
-                                                          received_coap_header->token_len);
-                                }
+
                                 // If the observe value is 0 means register for observation.
                                 if(number == 0) {
                                     tr_debug("M2MResourceInstance::handle_get_request - Put Resource under Observation");
@@ -445,6 +441,13 @@ sn_coap_hdr_s* M2MResourceInstance::handle_get_request(nsdl_s *nsdl,
                                     M2MBase::add_observation_level(M2MBase::R_Attribute);
                                     coap_response->options_list_ptr->observe = observation_number();
                                 }
+
+                                if(received_coap_header->token_ptr) {
+                                    tr_debug("M2MResourceInstance::handle_get_request - Sets Observation Token to resource");
+                                    set_observation_token(received_coap_header->token_ptr,
+                                                          received_coap_header->token_len);
+                                }
+
                             } else if (STOP_OBSERVATION == observe_option) {
                                 tr_debug("M2MResourceInstance::handle_get_request - Stops Observation");
                                 set_under_observation(false,NULL);


### PR DESCRIPTION
The token was not stored on all cases, which caused a some
testcases to fail. Now the observation token is set after the
report handler has been created, so there is a object where to
store the token.