### PR TITLE
m2mfirmware: fix compilation with DISABLE_BLOCK_MESSAGE

### DIFF
--- a/mbed-client/m2mbase.h
+++ b/mbed-client/m2mbase.h
@@ -362,7 +362,13 @@ public:
      * \param value[OUT] A pointer to the value of the token.
      * \param value_length[OUT] The length of the token pointer.
      */
-    void get_observation_token(uint8_t *&token, uint32_t &token_length);
+    void get_observation_token(const uint8_t *&token, uint32_t &token_length) const;
+
+    /**
+     * Deprecated compatibility wrapper for get_observation_token(const uint8_t*&),
+     * to be removed on next version.
+     */
+    void get_observation_token(uint8_t *&token, uint32_t &token_length) const;
 
     /**
      * \brief Returns the mode of the resource.

--- a/mbed-client/m2mfirmware.h
+++ b/mbed-client/m2mfirmware.h
@@ -238,6 +238,7 @@ public:
     bool set_resource_notification_sent_callback(FirmwareResource resource,
                                                  notification_sent_callback_2 callback);
 
+#ifndef DISABLE_BLOCK_MESSAGE
     /**
      * \brief Set incoming_block_message_callback for the package resource.
      *        The callback will be called when a block of the package has been received.
@@ -245,6 +246,7 @@ public:
      * \return true if successfully set, else false.
      */
     bool set_package_block_message_callback(incoming_block_message_callback callback);
+#endif
 
 private:
 

--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -210,7 +210,7 @@ public:
      * @brief Returns nsdl handle.
      * @return ndsl handle
      */
-    nsdl_s* get_nsdl_handle();
+    nsdl_s* get_nsdl_handle() const;
 
     /**
      * @brief Get endpoint name
@@ -256,36 +256,36 @@ private:
 
     bool create_nsdl_resource(M2MBase *base);
 
-    String coap_to_string(uint8_t *coap_data_ptr,
+    static String coap_to_string(const uint8_t *coap_data_ptr,
                           int coap_data_ptr_length);
 
     void execute_nsdl_process_loop();
 
-    uint64_t registration_time();
+    uint64_t registration_time() const;
 
     M2MBase* find_resource(const String &object,
-                           uint8_t *token = NULL,
-                           uint8_t token_len = 0);
+                           const uint8_t *token = NULL,
+                           uint8_t token_len = 0) const;
 
     M2MBase* find_resource(const M2MObject *object,
                            const String &object_instance,
-                           uint8_t *token = NULL,
-                           uint8_t token_len = 0);
+                           const uint8_t *token = NULL,
+                           uint8_t token_len = 0) const;
 
     M2MBase* find_resource(const M2MObjectInstance *object_instance,
                            const String &resource_instance,
-                           uint8_t *token = NULL,
-                           uint8_t token_len = 0);
+                           const uint8_t *token = NULL,
+                           uint8_t token_len = 0) const;
 
     M2MBase* find_resource(const M2MResource *resource,
                            const String &object_name,
                            const String &resource_instance,
-                           uint8_t *token = NULL,
-                           uint8_t token_len = 0);
+                           const uint8_t *token = NULL,
+                           uint8_t token_len = 0) const;
 
     bool object_present(M2MObject * object) const;
 
-    M2MInterface::Error interface_error(sn_coap_hdr_s *coap_header);
+    static M2MInterface::Error interface_error(const sn_coap_hdr_s &coap_header);
 
     void send_object_observation(M2MObject *object,
                                  uint16_t obs_number,

--- a/source/include/m2mreporthandler.h
+++ b/source/include/m2mreporthandler.h
@@ -103,7 +103,7 @@ public:
     /**
      * @brief Return write attribute flags.
      */
-    uint8_t attribute_flags();
+    uint8_t attribute_flags() const;
 
     /**
      * \brief Sets the observation token value.
@@ -113,11 +113,14 @@ public:
     void set_observation_token(const uint8_t *token, const uint8_t length);
 
     /**
-     * \brief Provides the observation token of the object.
+     * \brief Provides a copy of the observation token of the object.
      * \param value[OUT] A pointer to the value of the token.
      * \param value_length[OUT] The length of the token pointer.
      */
-    void get_observation_token(uint8_t *&token, uint32_t &token_length);
+    void get_observation_token(const uint8_t *&token, uint32_t &token_length) const;
+
+    /** Deprecated compatibility wrapper for get_observation_token(const uint8_t*&). */
+    void get_observation_token(uint8_t *&token, uint32_t &token_length) const;
 
     /**
      * \brief Returns the observation number.
@@ -182,7 +185,7 @@ private:
     /**
     * @brief Check whether notification params can be accepted.
     */
-    bool check_attribute_validity();
+    bool check_attribute_validity() const;
 
     /**
     * @brief Stop pmin & pmax timers.
@@ -193,13 +196,13 @@ private:
      * @brief Check if current value match threshold values.
      * @return True if notify can be send otherwise false.
      */
-    bool check_threshold_values();
+    bool check_threshold_values() const;
 
     /**
      * @brief Check whether current value matches with GT & LT.
      * @return True if current value match with GT or LT values.
      */
-    bool check_gt_lt_params();
+    bool check_gt_lt_params() const;
 
     /**
      * \brief Allocate (size + 1) amount of memory, copy size bytes into
@@ -207,7 +210,7 @@ private:
      * \param source The source string to copy, may not be NULL.
      * \param size The size of memory to be reserved.
     */
-    uint8_t* alloc_string_copy(const uint8_t* source, uint32_t size);
+    static uint8_t* alloc_string_copy(const uint8_t* source, uint32_t size);
 
 private:
     M2MReportObserver           &_observer;

--- a/source/m2mbase.cpp
+++ b/source/m2mbase.cpp
@@ -406,7 +406,14 @@ M2MBase::Observation M2MBase::observation_level() const
     return obs_level;
 }
 
-void M2MBase::get_observation_token(uint8_t *&token, uint32_t &token_length)
+void M2MBase::get_observation_token(uint8_t *&token, uint32_t &token_length) const
+{
+    if(_report_handler) {
+        _report_handler->get_observation_token(token, token_length);
+    }
+}
+
+void M2MBase::get_observation_token(const uint8_t *&token, uint32_t &token_length) const
 {
     if(_report_handler) {
         _report_handler->get_observation_token(token, token_length);

--- a/source/m2mfirmware.cpp
+++ b/source/m2mfirmware.cpp
@@ -682,6 +682,7 @@ bool M2MFirmware::set_resource_notification_sent_callback(FirmwareResource resou
     return false;
 }
 
+#ifndef DISABLE_BLOCK_MESSAGE
 bool M2MFirmware::set_package_block_message_callback(incoming_block_message_callback callback)
 {
     M2MResource* m2mresource;
@@ -695,4 +696,4 @@ bool M2MFirmware::set_package_block_message_callback(incoming_block_message_call
 
     return false;
 }
-
+#endif // DISABLE_BLOCK_MESSAGE

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -971,7 +971,7 @@ M2MBase* M2MNsdlInterface::find_resource(const String &object_name,
                     break;
                 }
             } else {
-                uint8_t *stored_token = 0;
+                const uint8_t *stored_token = 0;
                 uint32_t stored_token_length = 0;
                 (*it)->get_observation_token(stored_token, stored_token_length);
                 tr_debug("M2MNsdlInterface::find_resource(object level) - stored token (%s)", tr_array(stored_token, stored_token_length));
@@ -980,10 +980,7 @@ M2MBase* M2MNsdlInterface::find_resource(const String &object_name,
                             memcmp(token, stored_token, token_len) == 0) {
                         object = (*it);
                         tr_debug("M2MNsdlInterface::find_resource - token found");
-                        free(stored_token);
                         break;
-                    } else {
-                        free(stored_token);
                     }
                 }
             }
@@ -1017,7 +1014,7 @@ M2MBase* M2MNsdlInterface::find_resource(const M2MObject *object,
                         break;
                     }
                 } else {
-                    uint8_t *stored_token = 0;
+                    const uint8_t *stored_token = 0;
                     uint32_t stored_token_length = 0;
                     tr_debug("M2MNsdlInterface::find_resource(object instance level) - in token (%s)", tr_array(token, token_len));
                     (*it)->get_observation_token(stored_token, stored_token_length);
@@ -1026,10 +1023,7 @@ M2MBase* M2MNsdlInterface::find_resource(const M2MObject *object,
                         if (stored_token_length == token_len &&
                                 memcmp(token, stored_token, token_len) == 0) {
                             instance = (*it);
-                            free(stored_token);
                             break;
-                        } else {
-                            free(stored_token);
                         }
                     }
                 }
@@ -1069,7 +1063,7 @@ M2MBase* M2MNsdlInterface::find_resource(const M2MObjectInstance *object_instanc
                         }
                     }
                 } else {
-                    uint8_t *stored_token = 0;
+                    const uint8_t *stored_token = 0;
                     uint32_t stored_token_length = 0;
                     tr_debug("M2MNsdlInterface::find_resource(resource level) - in token (%s)", tr_array(token, token_len));
                     (*it)->get_observation_token(stored_token, stored_token_length);
@@ -1078,10 +1072,7 @@ M2MBase* M2MNsdlInterface::find_resource(const M2MObjectInstance *object_instanc
                         if (stored_token_length == token_len &&
                                 memcmp(token, stored_token, token_len) == 0) {
                             instance = *it;
-                            free(stored_token);
                             break;
-                        } else {
-                            free(stored_token);
                         }
                     }
                 }

--- a/source/m2mreporthandler.cpp
+++ b/source/m2mreporthandler.cpp
@@ -360,7 +360,7 @@ void M2MReportHandler::handle_timers()
     }
 }
 
-bool M2MReportHandler::check_attribute_validity()
+bool M2MReportHandler::check_attribute_validity() const
 {
     bool success = true;
     if ((_attribute_state & M2MReportHandler::Pmax) == M2MReportHandler::Pmax &&
@@ -405,7 +405,7 @@ void M2MReportHandler::set_default_values()
     _changed_instance_ids.clear();
 }
 
-bool M2MReportHandler::check_threshold_values()
+bool M2MReportHandler::check_threshold_values() const
 {
     tr_debug("M2MReportHandler::check_threshold_values");
     tr_debug("Current value: %f", _current_value);
@@ -438,7 +438,7 @@ bool M2MReportHandler::check_threshold_values()
     return can_send;
 }
 
-bool M2MReportHandler::check_gt_lt_params()
+bool M2MReportHandler::check_gt_lt_params() const
 {
     tr_debug("M2MReportHandler::check_gt_lt_params");
     bool can_send = false;
@@ -480,7 +480,7 @@ bool M2MReportHandler::check_gt_lt_params()
     return can_send;
 }
 
-uint8_t M2MReportHandler::attribute_flags()
+uint8_t M2MReportHandler::attribute_flags() const
 {
     return _attribute_state;
 }
@@ -499,16 +499,23 @@ void M2MReportHandler::set_observation_token(const uint8_t *token, const uint8_t
     }
 }
 
-void M2MReportHandler::get_observation_token(uint8_t *&token, uint32_t &token_length)
+void M2MReportHandler::get_observation_token(uint8_t *&token, uint32_t &token_length) const
 {
     token_length = 0;
     free(token);
+    token = NULL;
     if (_token) {
         token = alloc_string_copy((uint8_t *)_token, _token_length);
         if(token) {
             token_length = _token_length;
         }
     }
+}
+
+void M2MReportHandler::get_observation_token(const uint8_t *&token, uint32_t &token_length) const
+{
+    token = _token;
+    token_length = _token_length;
 }
 
 uint16_t M2MReportHandler::observation_number() const


### PR DESCRIPTION
After recent additions on master, the code did not compile
anymore with DISABLE_BLOCK_MESSAGE define. Fix this.