### PR TITLE
m2mbase: move the _observation_handler to m2mobject

### DIFF
--- a/mbed-client/m2mbase.h
+++ b/mbed-client/m2mbase.h
@@ -134,9 +134,9 @@ public:
 
     typedef struct lwm2m_parameters {
         //add multiple_instances
-        uint32_t            max_age;
+        uint32_t            max_age; // todo: add flag
         union {
-            char*               name; //for backwards compability
+            char*               name; //for backwards compatibility
             uint16_t            instance_id; // XXX: this is not properly aligned now, need to reorder these after the elimination is done
         } identifier;
         sn_nsdl_dynamic_resource_parameters_s *dynamic_resource_params;
@@ -262,13 +262,13 @@ public:
      * \brief Returns the Observation Handler object.
      * \return M2MObservationHandler object.
     */
-    M2MObservationHandler* observation_handler();
+    virtual M2MObservationHandler* observation_handler() const = 0;
 
     /**
      * \brief Sets the observation handler
      * \param handler Observation handler
     */
-    void set_observation_handler(M2MObservationHandler *handler);
+    virtual void set_observation_handler(M2MObservationHandler *handler) = 0;
 
     /**
      * \brief Sets the observation token value.
@@ -576,18 +576,23 @@ protected:
 
     static char* stringdup(const char* s);
 
+    /**
+     * \brief Delete the resource structures owned by this object. Note: this needs
+     * to be called separately from each subclass' destructor as this method uses a
+     * virtual method and the call needs to be done at same class which has the
+     * implementation of the pure virtual method.
+     */
+    void free_resources();
+
 private:
 
     static bool is_integer(const String &value);
 
     static bool is_integer(const char *value);
 
-    void free_resources();
-
 private:
     lwm2m_parameters_s          *_sn_resource;
     M2MReportHandler            *_report_handler; // TODO: can be broken down to smaller classes with inheritance.
-    M2MObservationHandler       *_observation_handler; // Not owned // TODO: This can be moved to higher level , M2MObject ?
 
 friend class Test_M2MBase;
 friend class Test_M2MObject;

--- a/mbed-client/m2mobject.h
+++ b/mbed-client/m2mobject.h
@@ -109,6 +109,18 @@ public:
     uint16_t instance_count() const;
 
     /**
+     * \brief Returns the Observation Handler object.
+     * \return M2MObservationHandler object.
+    */
+    virtual M2MObservationHandler* observation_handler() const;
+
+    /**
+     * \brief Sets the observation handler
+     * \param handler Observation handler
+    */
+    virtual void set_observation_handler(M2MObservationHandler *handler);
+
+    /**
      * \brief Adds the observation level for the object.
      * \param observation_level The level of observation.
      */
@@ -169,6 +181,8 @@ protected :
 private:
 
     M2MObjectInstanceList     _instance_list; // owned
+
+    M2MObservationHandler    *_observation_handler; // Not owned
 
 friend class Test_M2MObject;
 friend class Test_M2MInterfaceImpl;

--- a/mbed-client/m2mobjectinstance.h
+++ b/mbed-client/m2mobjectinstance.h
@@ -239,6 +239,18 @@ public:
     virtual void remove_observation_level(M2MBase::Observation observation_level);
 
     /**
+     * \brief Returns the Observation Handler object.
+     * \return M2MObservationHandler object.
+    */
+    virtual M2MObservationHandler* observation_handler() const;
+
+    /**
+     * \brief Sets the observation handler
+     * \param handler Observation handler
+    */
+    virtual void set_observation_handler(M2MObservationHandler *handler);
+
+    /**
      * \brief Handles GET request for the registered objects.
      * \param nsdl The NSDL handler for the CoAP library.
      * \param received_coap_header The CoAP message received from the server.

--- a/mbed-client/m2mresource.h
+++ b/mbed-client/m2mresource.h
@@ -178,6 +178,18 @@ public:
     bool delayed_response() const;
 
     /**
+     * \brief Returns the Observation Handler object.
+     * \return M2MObservationHandler object.
+    */
+    virtual M2MObservationHandler* observation_handler() const;
+
+    /**
+     * \brief Sets the observation handler
+     * \param handler Observation handler
+    */
+    virtual void set_observation_handler(M2MObservationHandler *handler);
+
+    /**
      * \brief Parses the received query for a notification
      * attribute.
      * \return True if required attributes are present, else false.

--- a/mbed-client/m2mresourceinstance.h
+++ b/mbed-client/m2mresourceinstance.h
@@ -103,6 +103,17 @@ private: // Constructor and destructor are private
 
 public:
 
+    /**
+     * \brief Returns the Observation Handler object.
+     * \return M2MObservationHandler object.
+    */
+    virtual M2MObservationHandler* observation_handler() const;
+
+    /**
+     * \brief Sets the observation handler
+     * \param handler Observation handler
+    */
+    virtual void set_observation_handler(M2MObservationHandler *handler);
 
     /**
      * \brief Parses the received query for a notification

--- a/source/m2mbase.cpp
+++ b/source/m2mbase.cpp
@@ -46,8 +46,7 @@ M2MBase::M2MBase(const String& resource_name,
                  M2MBase::DataType type)
 :
   _sn_resource(NULL),
-  _report_handler(NULL),
-  _observation_handler(NULL)
+  _report_handler(NULL)
 {
     // Checking the name length properly, i.e returning error is impossible from constructor without exceptions
     assert(resource_name.length() <= MAX_ALLOWED_STRING_LENGTH);
@@ -104,8 +103,7 @@ M2MBase::M2MBase(const String& resource_name,
 
 M2MBase::M2MBase(const lwm2m_parameters_s *s):
     _sn_resource((lwm2m_parameters_s*) s),
-    _report_handler(NULL),
-    _observation_handler(NULL)
+    _report_handler(NULL)
 {
     tr_debug("M2MBase::M2MBase(const lwm2m_parameters_s *s)");
     // Set callback function in case of both dynamic and static resource
@@ -116,7 +114,7 @@ M2MBase::~M2MBase()
 {
     tr_debug("M2MBase::~M2MBase()");
     delete _report_handler;
-    free_resources();
+
     value_updated_callback* callback = (value_updated_callback*)M2MCallbackStorage::remove_callback(*this, M2MCallbackAssociation::M2MBaseValueUpdatedCallback);
     delete callback;
 
@@ -283,12 +281,6 @@ void M2MBase::remove_observation_level(M2MBase::Observation obs_level)
     }
 }
 
-void M2MBase::set_observation_handler(M2MObservationHandler *handler)
-{
-    tr_debug("M2MBase::set_observation_handler - handler: 0x%p", (void*)handler);
-    _observation_handler = handler;
-}
-
 
 void M2MBase::set_under_observation(bool observed,
                                     M2MObservationHandler *handler)
@@ -298,7 +290,9 @@ void M2MBase::set_under_observation(bool observed,
     if(_report_handler) {
         _report_handler->set_under_observation(observed);
     }
-    _observation_handler = handler;
+
+    set_observation_handler(handler);
+
     if (handler) {
         if (base_type() != M2MBase::ResourceInstance) {
             // Create report handler only if it does not exist and one wants observation
@@ -464,11 +458,12 @@ void M2MBase::observation_to_be_sent(const m2m::Vector<uint16_t> &changed_instan
                                      bool send_object)
 {
     //TODO: Move this to M2MResourceInstance
-    if(_observation_handler) {
-        _observation_handler->observation_to_be_sent(this,
-                                                    obs_number,
-                                                    changed_instance_ids,
-                                                    send_object);
+    M2MObservationHandler *obs_handler = observation_handler();
+    if (obs_handler) {
+        obs_handler->observation_to_be_sent(this,
+                                            obs_number,
+                                            changed_instance_ids,
+                                            send_object);
     }
 }
 
@@ -587,11 +582,6 @@ M2MReportHandler* M2MBase::create_report_handler()
 M2MReportHandler* M2MBase::report_handler() const
 {
     return _report_handler;
-}
-
-M2MObservationHandler* M2MBase::observation_handler()
-{
-    return _observation_handler;
 }
 
 void M2MBase::set_register_uri(bool register_uri)
@@ -759,9 +749,10 @@ char* M2MBase::stringdup(const char* src)
 void M2MBase::free_resources()
 {
     // remove the nsdl structures from the nsdlinterface's lists.
-    if (_observation_handler) {
+    M2MObservationHandler *obs_handler = observation_handler();
+    if (obs_handler) {
         tr_debug("M2MBase::free_resources()");
-        _observation_handler->resource_to_be_deleted(this);
+        obs_handler->resource_to_be_deleted(this);
     }
 
     if (_sn_resource->dynamic_resource_params->static_resource_parameters->free_on_delete) {

--- a/source/m2mobject.cpp
+++ b/source/m2mobject.cpp
@@ -35,7 +35,8 @@ M2MObject::M2MObject(const String &object_name, char *path, bool external_blockw
 #endif
           path,
           external_blockwise_store,
-          false)
+          false),
+          _observation_handler(NULL)
 {
     M2MBase::set_base_type(M2MBase::Object);
     if(M2MBase::name_id() != -1) {
@@ -44,7 +45,8 @@ M2MObject::M2MObject(const String &object_name, char *path, bool external_blockw
 }
 
 M2MObject::M2MObject(const M2MBase::lwm2m_parameters_s* static_res)
-: M2MBase(static_res)
+: M2MBase(static_res),
+_observation_handler(NULL)
 {
     if(M2MBase::name_id() != -1) {
         M2MBase::set_coap_content_type(COAP_CONTENT_OMA_TLV_TYPE);
@@ -67,6 +69,8 @@ M2MObject::~M2MObject()
 
         _instance_list.clear();
     }
+
+    free_resources();
 }
 
 M2MObjectInstance* M2MObject::create_object_instance(uint16_t instance_id)
@@ -159,6 +163,18 @@ const M2MObjectInstanceList& M2MObject::instances() const
 uint16_t M2MObject::instance_count() const
 {
     return (uint16_t)_instance_list.size();
+}
+
+M2MObservationHandler* M2MObject::observation_handler() const
+{
+    // XXX: need to check the flag too
+    return _observation_handler;
+}
+
+void M2MObject::set_observation_handler(M2MObservationHandler *handler)
+{
+    tr_debug("M2MObject::set_observation_handler - handler: 0x%p", (void*)handler);
+    _observation_handler = handler;
 }
 
 void M2MObject::add_observation_level(M2MBase::Observation observation_level)

--- a/source/m2mobjectinstance.cpp
+++ b/source/m2mobjectinstance.cpp
@@ -68,6 +68,8 @@ M2MObjectInstance::~M2MObjectInstance()
         }
         _resource_list.clear();
     }
+
+    free_resources();
 }
 
 // TBD, ResourceType to the base class struct?? TODO!
@@ -387,6 +389,18 @@ uint16_t M2MObjectInstance::resource_count(const char *resource) const
         }
     }
     return count;
+}
+
+M2MObservationHandler* M2MObjectInstance::observation_handler() const
+{
+    // XXX: need to check the flag too
+    return _parent.observation_handler();
+}
+
+void M2MObjectInstance::set_observation_handler(M2MObservationHandler *handler)
+{
+    // XXX: need to set the flag too
+    _parent.set_observation_handler(handler);
 }
 
 void M2MObjectInstance::add_observation_level(M2MBase::Observation observation_level)

--- a/source/m2mresource.cpp
+++ b/source/m2mresource.cpp
@@ -106,6 +106,8 @@ M2MResource::~M2MResource()
 #ifndef DISABLE_DELAYED_RESPONSE
     free(_delayed_token);
 #endif
+
+    free_resources();
 }
 
 bool M2MResource::supports_multiple_instances() const
@@ -203,6 +205,22 @@ bool M2MResource::delayed_response() const
     return _delayed_response;
 }
 #endif
+
+M2MObservationHandler* M2MResource::observation_handler() const
+{
+    const M2MObjectInstance& parent_object_instance = get_parent_object_instance();
+
+    // XXX: need to check the flag too
+    return parent_object_instance.observation_handler();
+}
+
+void M2MResource::set_observation_handler(M2MObservationHandler *handler)
+{
+    M2MObjectInstance& parent_object_instance = get_parent_object_instance();
+
+    // XXX: need to set the flag too
+    parent_object_instance.set_observation_handler(handler);
+}
 
 bool M2MResource::handle_observation_attribute(const char *query)
 {

--- a/source/m2mresourcebase.cpp
+++ b/source/m2mresourcebase.cpp
@@ -253,9 +253,9 @@ void M2MResourceBase::report()
             }
         }
     } else if(M2MBase::Static == mode()) {
-        M2MObservationHandler *observation_handler = M2MBase::observation_handler();
-        if(observation_handler) {
-            observation_handler->value_updated(this);
+        M2MObservationHandler *obs_handler = observation_handler();
+        if(obs_handler) {
+            obs_handler->value_updated(this);
         }
     } else {
         tr_debug("M2MResourceBase::report() - mode = %d, is_observable = %d", mode(), is_observable());

--- a/source/m2mresourceinstance.cpp
+++ b/source/m2mresourceinstance.cpp
@@ -84,6 +84,23 @@ M2MResourceInstance::M2MResourceInstance(M2MResource &parent,
 
 M2MResourceInstance::~M2MResourceInstance()
 {
+    free_resources();
+}
+
+M2MObservationHandler* M2MResourceInstance::observation_handler() const
+{
+    const M2MResource& parent_resource = get_parent_resource();
+
+    // XXX: need to check the flag too
+    return parent_resource.observation_handler();
+}
+
+void M2MResourceInstance::set_observation_handler(M2MObservationHandler *handler)
+{
+    M2MResource& parent_resource = get_parent_resource();
+
+    // XXX: need to set the flag too
+    parent_resource.set_observation_handler(handler);
 }
 
 bool M2MResourceInstance::handle_observation_attribute(const char *query)
@@ -115,7 +132,6 @@ uint16_t M2MResourceInstance::object_instance_id() const
     const M2MObjectInstance& parent_object_instance = get_parent_resource().get_parent_object_instance();
     return parent_object_instance.instance_id();
 }
-
 
 M2MResource& M2MResourceInstance::get_parent_resource() const
 {


### PR DESCRIPTION
NOTE - this change is not ready yet. I may need to implement
the storage of level in object hierarchy where the observer
was set.

Move the _observation_handler -pointer from m2mbase to
the m2mobject class. This saves four bytes of memory
on each object instance, resource and resource instance.