### PR TITLE
Add support for TLV binary integers (#463)

### DIFF
--- a/mbed-client/m2mresourceinstance.h
+++ b/mbed-client/m2mresourceinstance.h
@@ -199,7 +199,7 @@ public:
      * \brief Converts a value to integer and returns it. Note: Conversion
      * errors are not detected.
      */
-    int get_value_int();
+    int64_t get_value_int() const;
 
     /**
      * Get the value as a string object. No encoding/charset conversions

--- a/module.json
+++ b/module.json
@@ -7,8 +7,10 @@
   "homepage": "https://github.com/ARMmbed/mbed-client",
   "license": "Apache-2.0",
   "dependencies": {
+
     "mbed-client-c": "ARMmbed/mbed-client-c#mbed-cloud-client-rel1.2",
     "mbed-trace": ">=0.2.0,<2.0.0"
+    "nanostack-libservice": "^3.0.0"
   },
   "targetDependencies": {
     "arm": {

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
   "dependencies": {
 
     "mbed-client-c": "ARMmbed/mbed-client-c#mbed-cloud-client-rel1.2",
-    "mbed-trace": ">=0.2.0,<2.0.0"
+    "mbed-trace": ">=0.2.0,<2.0.0",
     "nanostack-libservice": "^3.0.0"
   },
   "targetDependencies": {

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -32,7 +32,8 @@ find ./build -name '*.xml' | xargs cp -t ./results/
 find ./build/x86-linux-native-coverage/test -name '*.gcno' | xargs cp -t ./coverage/
 find ./build/x86-linux-native-coverage/test -name '*.gcda' | xargs cp -t ./coverage/
 touch coverage/*.gcda
-exclude_files="${PWD}/test/"
+exclude_files="${PWD}/test/|${PWD}/yotta_modules*"
+#exclude_files2="${PWD}/yotta_modules*"
 gcovr -r ./ --gcov-filter='.*source*.' --exclude-unreachable-branches --exclude $exclude_files --object-directory ./coverage -x -o ./results/gcovr.xml
 echo
 echo "Create coverage document"

--- a/source/include/m2mtlvserializer.h
+++ b/source/include/m2mtlvserializer.h
@@ -95,4 +95,6 @@ private :
     static void serialize_id(uint16_t id, uint32_t &size, uint8_t *id_ptr);
 
     static void serialize_length(uint32_t length, uint32_t &size, uint8_t *length_ptr);
+
+    static bool serialize_TLV_binary_int(const M2MResourceInstance *resource, uint8_t type, uint16_t id, uint8_t *&data, uint32_t &size);
 };

--- a/source/m2mresourceinstance.cpp
+++ b/source/m2mresourceinstance.cpp
@@ -337,17 +337,12 @@ void M2MResourceInstance::get_value(uint8_t *&value, uint32_t &value_length)
     }
 }
 
-int M2MResourceInstance::get_value_int()
+int64_t M2MResourceInstance::get_value_int() const
 {
-    int value_int = 0;
-    // Get the value and convert it into integer. This is not the most
-    // efficient way, as it takes pointless heap copy to get the zero termination.
-    uint8_t* buffer = NULL;
-    uint32_t length;
-    get_value(buffer,length);
-    if(buffer) {
-        value_int = atoi((const char*)buffer);
-        free(buffer);
+    int64_t value_int = 0;
+
+    if(_value) {
+        value_int = atoll((const char*)_value);
     }
     return value_int;
 }

--- a/test/mbedclient/utest/m2mtlvdeserializer/CMakeLists.txt
+++ b/test/mbedclient/utest/m2mtlvdeserializer/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(m2mtlv
 target_link_libraries(m2mtlv
     CppUTest
     CppUTestExt
+    nanostack-libservice
 )
 set_target_properties(m2mtlv
 PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS}"

--- a/test/mbedclient/utest/stub/m2mresourceinstance_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mresourceinstance_stub.cpp
@@ -170,20 +170,16 @@ void M2MResourceInstance::get_value(uint8_t *&value, uint32_t &value_length)
     }
 }
 
-int M2MResourceInstance::get_value_int()
+int64_t M2MResourceInstance::get_value_int() const
 {
     // Note: this is a copy-paste from the original version, as the tests
     // set only m2mresourceinstance_stub::value.
 
     int value_int = 0;
-    // Get the value and convert it into integer. This is not the most
-    // efficient way, as it takes pointless heap copy to get the zero termination.
-    uint8_t* buffer = NULL;
-    uint32_t length;
-    get_value(buffer,length);
+    uint8_t* buffer = m2mresourceinstance_stub::value;
+
     if(buffer) {
         value_int = atoi((const char*)buffer);
-        free(buffer);
     }
     return value_int;
 }


### PR DESCRIPTION
This support TLV binary formats Integer, Boolean and Time.

If resource type is INTEGER then value will convert to 64-bit binary buffer. Format is two's complement big endian word. See, OMA-TS-LightweightM2M-V1_0-20170208-A, Appendix C, data Types, Integer, TLV Format.