### PR TITLE
Stopping NSDL execution timer in Queue Mode.

### DIFF
--- a/source/include/m2mnsdlinterface.h
+++ b/source/include/m2mnsdlinterface.h
@@ -21,6 +21,7 @@
 #include "mbed-client/m2minterface.h"
 #include "mbed-client/m2mtimerobserver.h"
 #include "mbed-client/m2mobservationhandler.h"
+#include "mbed-client/m2mtimer.h"
 #include "mbed-client/m2mbase.h"
 #include "mbed-client/m2mserver.h"
 #include "include/nsdllinker.h"
@@ -33,7 +34,6 @@ class M2MResource;
 class M2MResourceInstance;
 class M2MNsdlObserver;
 class M2MServer;
-class M2MTimer;
 class M2MConnectionHandler;
 
 typedef Vector<M2MObject *> M2MObjectList;
@@ -235,6 +235,8 @@ public:
      */
     void set_server_address(const char *server_address);
 
+    M2MTimer &get_nsdl_execution_timer();
+
 protected: // from M2MTimerObserver
 
     virtual void timer_expired(M2MTimerObserver::Type type);
@@ -409,6 +411,8 @@ private:
     */
     bool parse_and_send_uri_query_parameters();
 
+    void start_nsdl_execution_timer();
+
 private:
 
     M2MNsdlObserver                         &_observer;
@@ -417,8 +421,8 @@ private:
     nsdl_s                                  *_nsdl_handle;
     M2MSecurity                             *_security; // Not owned
     M2MServer                               _server;
-    M2MTimer                                *_nsdl_exceution_timer;
-    M2MTimer                                *_registration_timer;
+    M2MTimer                                _nsdl_exceution_timer;
+    M2MTimer                                _registration_timer;
     M2MConnectionHandler                    &_connection_handler;
     sn_nsdl_addr_s                          _sn_nsdl_address;
     String                                  _endpoint_name;
@@ -427,6 +431,7 @@ private:
     char                                    *_server_address; // BS or M2M address
     bool                                    _unregister_ongoing;
     bool                                    _identity_accepted;
+    bool                                    _nsdl_exceution_timer_running;
 
 friend class Test_M2MNsdlInterface;
 

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -520,6 +520,8 @@ void M2MInterfaceImpl::timer_expired(M2MTimerObserver::Type type)
 {
     tr_debug("M2MInterfaceImpl::timer_expired()");
     if(M2MTimerObserver::QueueSleep == type) {
+        M2MTimer &timer = _nsdl_interface.get_nsdl_execution_timer();
+        timer.stop_timer();
         if(_callback_handler) {
             _callback_handler();
         }

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -40,7 +40,6 @@
 #include "mbed-client/m2mresource.h"
 #include "mbed-client/m2mconstants.h"
 #include "mbed-trace/mbed_trace.h"
-#include "mbed-client/m2mtimer.h"
 #include "sn_grs.h"
 #include "mbed-client/m2minterfacefactory.h"
 #include "mbed-client/m2mdevice.h"
@@ -59,14 +58,15 @@ M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer, M2MConnectionHandl
   _nsdl_handle(NULL),
   _security(NULL),
   _server(),
-  _nsdl_exceution_timer(new M2MTimer(*this)),
-  _registration_timer(new M2MTimer(*this)),
+  _nsdl_exceution_timer(*this),
+  _registration_timer(*this),
   _connection_handler(connection_handler),
   _counter_for_nsdl(0),
   _bootstrap_id(0),
   _server_address(NULL),
   _unregister_ongoing(false),
-  _identity_accepted(false)
+  _identity_accepted(false),
+  _nsdl_exceution_timer_running(false)
 {
     tr_debug("M2MNsdlInterface::M2MNsdlInterface()");
     _sn_nsdl_address.addr_len = 0;
@@ -93,8 +93,6 @@ M2MNsdlInterface::~M2MNsdlInterface()
          memory_free(_endpoint->lifetime_ptr);
          memory_free(_endpoint);
     }
-    delete _nsdl_exceution_timer;
-    delete _registration_timer;
     _object_list.clear();
     _security = NULL;
 
@@ -232,6 +230,7 @@ bool M2MNsdlInterface::create_bootstrap_resource(sn_nsdl_addr_s *address)
              _endpoint->endpoint_name_ptr);
 
     if(_bootstrap_id == 0) {
+        start_nsdl_execution_timer();
         // Take copy of the address, uri_query_parameters() will modify the source buffer
         bool msg_sent = false;
         if (_server_address) {
@@ -290,10 +289,8 @@ void M2MNsdlInterface::set_server_address(uint8_t* address,
 bool M2MNsdlInterface::send_register_message()
 {
     tr_debug("M2MNsdlInterface::send_register_message()");
-    _nsdl_exceution_timer->stop_timer();
-    _nsdl_exceution_timer->start_timer(ONE_SECOND_TIMER * 1000,
-                                       M2MTimerObserver::NsdlExecution,
-                                       false);
+    start_nsdl_execution_timer();
+
     bool success = false;
     if (_server_address) {
         success = parse_and_send_uri_query_parameters();
@@ -308,6 +305,7 @@ bool M2MNsdlInterface::send_register_message()
 bool M2MNsdlInterface::send_update_registration(const uint32_t lifetime)
 {
     tr_debug("M2MNsdlInterface::send_update_registration( lifetime %" PRIu32 ")", lifetime);
+    start_nsdl_execution_timer();
     bool success = false;
     create_nsdl_list_structure(_object_list);
 
@@ -320,8 +318,8 @@ bool M2MNsdlInterface::send_update_registration(const uint32_t lifetime)
         }
         set_endpoint_lifetime_buffer(lifetime);
 
-        _registration_timer->stop_timer();
-        _registration_timer->start_timer(registration_time() * 1000,
+        _registration_timer.stop_timer();
+        _registration_timer.start_timer(registration_time() * 1000,
                                          M2MTimerObserver::Registration,
                                          false);
         if(_nsdl_handle &&
@@ -433,8 +431,8 @@ uint8_t M2MNsdlInterface::received_from_server_callback(struct nsdl_s *nsdl_hand
 
                 }
                 if(_endpoint->lifetime_ptr) {
-                    _registration_timer->stop_timer();
-                    _registration_timer->start_timer(registration_time() * 1000,
+                    _registration_timer.stop_timer();
+                    _registration_timer.start_timer(registration_time() * 1000,
                                                      M2MTimerObserver::Registration,
                                                      false);
                 }
@@ -454,7 +452,7 @@ uint8_t M2MNsdlInterface::received_from_server_callback(struct nsdl_s *nsdl_hand
             _unregister_ongoing = false;
             tr_debug("M2MNsdlInterface::received_from_server_callback - unregistration callback");
             if(coap_header->msg_code == COAP_MSG_CODE_RESPONSE_DELETED) {
-                _registration_timer->stop_timer();
+                _registration_timer.stop_timer();
                 _observer.client_unregistered();
             } else {
                 tr_error("M2MNsdlInterface::received_from_server_callback - unregistration error %d", coap_header->msg_code);
@@ -467,7 +465,7 @@ uint8_t M2MNsdlInterface::received_from_server_callback(struct nsdl_s *nsdl_hand
                 _observer.registration_updated(_server);
             } else {
                 tr_error("M2MNsdlInterface::received_from_server_callback - registration_updated failed %d", coap_header->msg_code);
-                _registration_timer->stop_timer();
+                _registration_timer.stop_timer();
                 bool msg_sent = false;
                 if (_server_address) {
                     msg_sent = parse_and_send_uri_query_parameters();
@@ -733,12 +731,10 @@ bool M2MNsdlInterface::process_received_data(uint8_t *data,
 void M2MNsdlInterface::stop_timers()
 {
     tr_debug("M2MNsdlInterface::stop_timers()");
-    if(_registration_timer) {
-        _registration_timer->stop_timer();
-    }
-    if (_nsdl_exceution_timer) {
-        _nsdl_exceution_timer->stop_timer();
-    }
+    _registration_timer.stop_timer();
+    _nsdl_exceution_timer.stop_timer();
+    _nsdl_exceution_timer_running = false;
+    _counter_for_nsdl = 0;
     _bootstrap_id = 0;
     _unregister_ongoing = false;
 }
@@ -1357,6 +1353,9 @@ void M2MNsdlInterface::send_notification(uint8_t *token,
 
 {
     tr_debug("M2MNsdlInterface::send_notification");
+    if(!_nsdl_exceution_timer_running) {
+        send_update_registration();
+    }
     sn_coap_hdr_s *notification_message_ptr;
 
     /* Allocate and initialize memory for header struct */
@@ -1756,6 +1755,11 @@ void M2MNsdlInterface::set_server_address(const char* server_address)
     _server_address = M2MBase::alloc_string_copy(server_address);
 }
 
+M2MTimer &M2MNsdlInterface::get_nsdl_execution_timer()
+{
+    return _nsdl_exceution_timer;
+}
+
 bool M2MNsdlInterface::parse_and_send_uri_query_parameters()
 {
     bool msg_sent = false;
@@ -1786,4 +1790,14 @@ void M2MNsdlInterface::claim_mutex()
 void M2MNsdlInterface::release_mutex()
 {
     _connection_handler.release_mutex();
+}
+
+void M2MNsdlInterface::start_nsdl_execution_timer()
+{
+    tr_debug("M2MNsdlInterface::start_nsdl_execution_timer");
+    _nsdl_exceution_timer_running = true;
+    _nsdl_exceution_timer.stop_timer();
+    _nsdl_exceution_timer.start_timer(ONE_SECOND_TIMER * 1000,
+                                       M2MTimerObserver::NsdlExecution,
+                                      false);
 }

--- a/test/mbedclient/utest/m2mnsdlinterface/m2mnsdlinterfacetest.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/m2mnsdlinterfacetest.cpp
@@ -196,3 +196,8 @@ TEST(M2MNsdlInterface, internal_endpoint_name)
 {
     m2m_nsdl_interface->test_internal_endpoint_name();
 }
+
+TEST(M2MNsdlInterface, get_nsdl_execution_timer)
+{
+    m2m_nsdl_interface->test_get_nsdl_execution_timer();
+}

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.cpp
@@ -26,6 +26,7 @@
 #include "m2mbase_stub.h"
 #include "m2mserver.h"
 #include "m2msecurity.h"
+#include "m2mtimer.h"
 #include "m2mconnectionsecurity.h"
 #include "m2mtlvdeserializer_stub.h"
 #include "uriqueryparser_stub.h"
@@ -1920,4 +1921,10 @@ void Test_M2MNsdlInterface::test_internal_endpoint_name()
     free(nsdl->_nsdl_handle->ep_information_ptr->location_ptr);
     free(nsdl->_nsdl_handle->ep_information_ptr);
     free(nsdl->_nsdl_handle);
+}
+
+void Test_M2MNsdlInterface::test_get_nsdl_execution_timer()
+{
+    M2MTimer &timer = nsdl->get_nsdl_execution_timer();
+    (void)timer;
 }

--- a/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
+++ b/test/mbedclient/utest/m2mnsdlinterface/test_m2mnsdlinterface.h
@@ -96,6 +96,8 @@ public:
 
     void test_internal_endpoint_name();
 
+    void test_get_nsdl_execution_timer();
+
     M2MNsdlInterface* nsdl;
 
     TestObserver *observer;

--- a/test/mbedclient/utest/nsdlaccesshelper/CMakeLists.txt
+++ b/test/mbedclient/utest/nsdlaccesshelper/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(nsdlaccesshelper
         "../stub/m2mbase_stub.cpp"
         "../stub/m2mobject_stub.cpp"
         "../stub/m2mstringbufferbase_stub.cpp"
+        "../stub/m2mtimer_stub.cpp"
 )
 
 target_link_libraries(nsdlaccesshelper

--- a/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
+++ b/test/mbedclient/utest/stub/m2mnsdlinterface_stub.cpp
@@ -30,7 +30,10 @@ void m2mnsdlinterface_stub::clear()
 }
 
 M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver &observer, M2MConnectionHandler &connection_handler)
-: _observer(observer), _connection_handler(connection_handler)
+: _observer(observer),
+  _connection_handler(connection_handler),
+  _nsdl_exceution_timer(*this),
+  _registration_timer(*this)
 {
     //m2mnsdlinterface_stub::string_value = new String("");
 }
@@ -227,4 +230,9 @@ void M2MNsdlInterface::update_endpoint(const String &name)
 const String M2MNsdlInterface::internal_endpoint_name() const
 {
     return *m2mnsdlinterface_stub::string_value;
+}
+
+M2MTimer &M2MNsdlInterface::get_nsdl_execution_timer()
+{
+    return _nsdl_exceution_timer;
 }


### PR DESCRIPTION
This commit would help devices to go to deep sleep mode when in Queue mode as the 1 seconds NSDL timer will be shutdown.
The timer will re-start whenever there is a notfication activity or registration Update timer (which is a very long timer) is triggered.