### PR TITLE
By default, changing the COAP_BLOCKWISE option to be disabled.

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -8,7 +8,7 @@
         "disable-bootstrap-feature": null,
         "coap-disable-obs-feature":null,
         "reconnection-loop": 1,
-        "sn-coap-max-blockwise-payload-size" : 0,
+        "sn-coap-max-blockwise-payload-size" : null,
         "sn-coap-duplication-max-msgs-count": null,
         "sn-coap-max-incoming-message-size": null,
         "sn-coap-resending-queue-size-msgs": null,


### PR DESCRIPTION
This change can then be used to overwrite this option consistently across different build system
using same SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE macro.